### PR TITLE
feat: Issue #3 MVP 共通レイアウト（Header/Footer/Section）

### DIFF
--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -1,0 +1,87 @@
+import { anchorHref } from "../_lib/anchors";
+import { getFooterCtaItems } from "../_lib/navigation";
+import { SITE } from "../_lib/site";
+
+function FooterButton({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-900 px-4 text-sm font-medium text-white hover:opacity-90 dark:bg-zinc-50 dark:text-zinc-950"
+    >
+      {children}
+    </a>
+  );
+}
+
+function DisabledButton({ label }: { label: string }) {
+  return (
+    <span
+      aria-disabled="true"
+      className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-200 px-4 text-sm font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+      title="準備中"
+    >
+      {label}（準備中）
+    </span>
+  );
+}
+
+export function Footer() {
+  const ctas = getFooterCtaItems();
+  const bookingAnchor = anchorHref("booking");
+
+  return (
+    <footer className="border-t border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black">
+      <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
+        <div className="flex flex-col gap-8 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+              {SITE.name}
+            </div>
+            <div className="text-sm text-zinc-600 dark:text-zinc-400">{SITE.address}</div>
+            <a
+              href={SITE.mapUrl}
+              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              地図（Googleマップ）
+            </a>
+          </div>
+
+          <div className="space-y-3">
+            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+              予約
+            </div>
+            <div className="flex flex-col items-start gap-3">
+              {ctas.map((cta) =>
+                cta.disabled || !cta.href ? (
+                  <DisabledButton key={cta.key} label={cta.label} />
+                ) : (
+                  <FooterButton key={cta.key} href={cta.href}>
+                    {cta.label}
+                  </FooterButton>
+                ),
+              )}
+              <a
+                href={bookingAnchor}
+                className="text-sm text-zinc-600 underline-offset-4 hover:underline dark:text-zinc-400"
+              >
+                予約・問い合わせセクションへ
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-10 text-xs text-zinc-500 dark:text-zinc-500">
+          © {new Date().getFullYear()} {SITE.name}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { getHeaderNavItems } from "../_lib/navigation";
+import { SITE } from "../_lib/site";
+
+function HeaderLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
+    >
+      {children}
+    </a>
+  );
+}
+
+function DisabledItem({ label }: { label: string }) {
+  return (
+    <span
+      aria-disabled="true"
+      className="inline-flex items-center gap-2 text-sm font-medium text-zinc-500 dark:text-zinc-400"
+      title="準備中"
+    >
+      <span>{label}</span>
+      <span className="rounded-md border border-zinc-200 px-2 py-0.5 text-xs dark:border-zinc-800">
+        準備中
+      </span>
+    </span>
+  );
+}
+
+export function Header() {
+  const items = getHeaderNavItems();
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-zinc-200 bg-white/90 backdrop-blur dark:border-zinc-800 dark:bg-black/80">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
+        <Link
+          href="/"
+          className="text-sm font-semibold tracking-tight text-zinc-900 dark:text-zinc-50"
+        >
+          {SITE.name}
+        </Link>
+
+        <nav aria-label="主要ナビゲーション">
+          <ul className="flex items-center gap-4">
+            {items.map((item) => (
+              <li key={item.key}>
+                {item.disabled || !item.href ? (
+                  <DisabledItem label={item.label} />
+                ) : (
+                  <HeaderLink href={item.href}>{item.label}</HeaderLink>
+                )}
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/app/_components/Section.tsx
+++ b/app/_components/Section.tsx
@@ -1,0 +1,41 @@
+type HeadingLevel = 2 | 3;
+
+type Props = {
+  id?: string;
+  title: string;
+  lead?: string;
+  headingLevel?: HeadingLevel;
+  children?: React.ReactNode;
+};
+
+export function Section({
+  id,
+  title,
+  lead,
+  headingLevel = 2,
+  children,
+}: Props) {
+  const HeadingTag = headingLevel === 3 ? "h3" : "h2";
+  const headingClassName =
+    headingLevel === 3
+      ? "text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50"
+      : "text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50";
+
+  return (
+    <section id={id} className="py-12 sm:py-16">
+      <div className="mx-auto max-w-6xl space-y-6 px-4 sm:px-6">
+        <header className="space-y-2">
+          <HeadingTag className={headingClassName}>
+            {title}
+          </HeadingTag>
+          {lead ? (
+            <p className="max-w-3xl text-base leading-7 text-zinc-600 dark:text-zinc-400">
+              {lead}
+            </p>
+          ) : null}
+        </header>
+        {children ? <div className="space-y-4">{children}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/app/_lib/anchors.ts
+++ b/app/_lib/anchors.ts
@@ -1,0 +1,11 @@
+export const ANCHOR_IDS = {
+  pricing: "pricing",
+  access: "access",
+  booking: "booking",
+} as const;
+
+export type AnchorKey = keyof typeof ANCHOR_IDS;
+
+export function anchorHref(key: AnchorKey): `#${string}` {
+  return `#${ANCHOR_IDS[key]}`;
+}

--- a/app/_lib/navigation.ts
+++ b/app/_lib/navigation.ts
@@ -1,0 +1,44 @@
+import { anchorHref } from "./anchors";
+
+export type NavItem = {
+  key: "booking" | "pricing" | "access";
+  label: string;
+  href?: string;
+  disabled?: boolean;
+};
+
+export function getHeaderNavItems(): NavItem[] {
+  const bookingUrl = process.env.NEXT_PUBLIC_BOOKING_URL;
+
+  return [
+    {
+      key: "booking",
+      label: "予約",
+      href: bookingUrl,
+      disabled: !bookingUrl,
+    },
+    {
+      key: "pricing",
+      label: "料金",
+      href: anchorHref("pricing"),
+    },
+    {
+      key: "access",
+      label: "アクセス",
+      href: anchorHref("access"),
+    },
+  ];
+}
+
+export function getFooterCtaItems(): NavItem[] {
+  const bookingUrl = process.env.NEXT_PUBLIC_BOOKING_URL;
+
+  return [
+    {
+      key: "booking",
+      label: "ご宿泊予約",
+      href: bookingUrl,
+      disabled: !bookingUrl,
+    },
+  ];
+}

--- a/app/_lib/site.ts
+++ b/app/_lib/site.ts
@@ -1,0 +1,7 @@
+export const SITE = {
+  name: "TATEYAMA BASE 北条",
+  address: "〒294-0045 千葉県館山市北条2278-3",
+  mapUrl:
+    process.env.NEXT_PUBLIC_MAP_URL ??
+    "https://maps.app.goo.gl/n8sJhzN3JK3f2L2QA",
+} as const;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Footer } from "./_components/Footer";
+import { Header } from "./_components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,8 +25,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
-      <body className="flex min-h-full flex-col">{children}</body>
+    <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+      <body className="flex min-h-full flex-col bg-zinc-50 font-sans text-zinc-900 dark:bg-black dark:text-zinc-50">
+        <Header />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,65 +1,101 @@
-import Image from "next/image";
+import { Section } from "./_components/Section";
+import { ANCHOR_IDS, anchorHref } from "./_lib/anchors";
+import { getFooterCtaItems } from "./_lib/navigation";
+import { SITE } from "./_lib/site";
 
 export default function Home() {
+  const ctas = getFooterCtaItems();
+
   return (
-    <div className="flex flex-1 flex-col items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex w-full max-w-3xl flex-1 flex-col items-center justify-between bg-white px-16 py-32 sm:items-start dark:bg-black">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl leading-10 font-semibold tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
+    <div className="flex flex-1 flex-col">
+      <div className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black">
+        <div className="mx-auto max-w-6xl space-y-6 px-4 py-14 sm:px-6 sm:py-16">
+          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">{SITE.name}</h1>
+          <p className="max-w-3xl text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            館山駅から徒歩約9分、海まで徒歩約30秒。4〜8名で泊まれる1棟貸しの貸別荘です。
+          </p>
+          <div className="flex flex-wrap items-center gap-4">
             <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
+              href={anchorHref("pricing")}
+              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
             >
-              Templates
-            </a>{" "}
-            or the{" "}
+              料金を見る
+            </a>
             <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
+              href={anchorHref("access")}
+              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
             >
-              Learning
-            </a>{" "}
-            center.
+              アクセスを見る
+            </a>
+            <a
+              href={anchorHref("booking")}
+              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
+            >
+              予約・問い合わせへ
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <Section
+        id={ANCHOR_IDS.pricing}
+        title="料金"
+        lead="料金はシーズンや人数によって変わります。詳細は順次整備します。"
+      >
+        <p className="text-base leading-7 text-zinc-600 dark:text-zinc-400">
+          MVPではまず導線と見出し構造を固定し、後続Issueで料金表を実装します。
+        </p>
+      </Section>
+
+      <Section
+        id={ANCHOR_IDS.access}
+        title="アクセス"
+        lead="住所と地図リンクは固定で掲載します。"
+      >
+        <div className="space-y-2 text-base leading-7 text-zinc-600 dark:text-zinc-400">
+          <div>{SITE.address}</div>
+          <a
+            href={SITE.mapUrl}
+            className="inline-flex text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Googleマップで開く
+          </a>
+        </div>
+      </Section>
+
+      <Section
+        id={ANCHOR_IDS.booking}
+        title="予約・問い合わせ"
+        lead="予約は外部サービス（STORES）を利用します。"
+      >
+        <div className="flex flex-col items-start gap-3">
+          {ctas.map((cta) =>
+            cta.disabled || !cta.href ? (
+              <span
+                key={cta.key}
+                aria-disabled="true"
+                className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-200 px-4 text-sm font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                title="準備中"
+              >
+                {cta.label}（準備中）
+              </span>
+            ) : (
+              <a
+                key={cta.key}
+                href={cta.href}
+                className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-900 px-4 text-sm font-medium text-white hover:opacity-90 dark:bg-zinc-50 dark:text-zinc-950"
+              >
+                {cta.label}
+              </a>
+            ),
+          )}
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            予約URLが未設定の場合は「準備中」と表示されます。
           </p>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="bg-foreground text-background flex h-12 w-full items-center justify-center gap-2 rounded-full px-5 transition-opacity hover:opacity-90 md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] md:w-[158px] dark:border-white/[.145] dark:hover:bg-white/[.08]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+      </Section>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
1ページLPの骨格として、共通レイアウト（Header / Footer / Section）を最小実装しました。以降のセクション実装を高速化するための土台です。

## 対応内容
- Headerに「予約/料金/アクセス」を常設（docs/IA.md準拠）
- Footerに施設名/住所/地図/CTA再掲の置き場を用意
- Sectionコンポーネントで「見出し＋本文」の共通枠を提供
- アンカーIDを固定：#pricing / #access / #booking
- ナビ/リンク先定義を1箇所に集約（将来のページ分割に備える）

## 受け入れ条件（AC）
- Headerに「予約/料金/アクセス」が常設されている
- Footerに施設名/住所/地図/CTA再掲が置ける
- 見出し階層が崩れない（h1は1つ、以降h2/h3）
- アンカーIDが固定されている：#pricing / #access / #booking

## 動作確認
- npm run lint
- npm run build

## 補足
- 予約URLは `NEXT_PUBLIC_BOOKING_URL` 未設定時「準備中」扱いで無効化しています（docs/IA.mdの方針に合わせた挙動）。