### PR TITLE
feat: MVP Hero + CTAButton（準備中フォールバック）#4

### DIFF
--- a/app/_components/CTAButton.tsx
+++ b/app/_components/CTAButton.tsx
@@ -1,0 +1,107 @@
+/**
+ * CTAButton — 行動喚起ボタンコンポーネント
+ *
+ * 役割（variant）に応じてスタイルを変え、URL 未設定時は「準備中」で無効化する。
+ *
+ * variant の使い分け（docs/DESIGN.md 8.4 より）:
+ *   - "primary"   : 最も押してほしい行動（塗り）   例: ご宿泊予約
+ *   - "secondary" : 次点の補助行動（枠）           例: LINE で問い合わせ
+ *   - "tertiary"  : 補助的なリンク（テキスト下線） 例: Googleマップで開く
+ *
+ * 無効化（URL 未設定時）:
+ *   - ボタン文言を「準備中」に切り替える
+ *   - クリック不可（aria-disabled + カーソル禁止）
+ *   - description が渡された場合は 1 行の補足説明を直下に表示する
+ */
+
+type Variant = "primary" | "secondary" | "tertiary";
+
+type CTAButtonProps = {
+  /** ボタンの重要度（デフォルト: "primary"） */
+  variant?: Variant;
+  /**
+   * リンク先 URL。
+   * undefined または空文字の場合、ボタンは「準備中」として無効化される。
+   */
+  href?: string;
+  /** 有効時に表示するボタン文言 */
+  children: React.ReactNode;
+  /**
+   * 無効時（準備中）に表示する補足説明文。
+   * 例: "予約（STORES）は準備中です。"
+   */
+  description?: string;
+  /** true の場合 target="_blank" + rel="noopener noreferrer" を付与する */
+  external?: boolean;
+};
+
+// ---- スタイル定義 ----
+
+/** すべての variant に共通するベースクラス */
+const BASE =
+  "inline-flex h-11 items-center justify-center rounded-lg px-5 text-sm font-medium transition-opacity";
+
+/** 有効時の variant 別スタイル */
+const VARIANT_STYLES: Record<Variant, string> = {
+  primary:
+    "bg-zinc-900 text-white hover:opacity-90 dark:bg-zinc-50 dark:text-zinc-950",
+  secondary:
+    "border border-zinc-900 text-zinc-900 hover:opacity-80 dark:border-zinc-50 dark:text-zinc-50",
+  tertiary:
+    "text-zinc-900 underline underline-offset-4 hover:opacity-70 dark:text-zinc-50",
+};
+
+/**
+ * 無効状態のクラスを生成する。
+ * DESIGN.md の「薄くする（opacity）＋カーソル禁止」に準拠し、
+ * variant の色はそのままに opacity-40 + cursor-not-allowed を重ねる。
+ */
+function disabledClass(variant: Variant): string {
+  return `${VARIANT_STYLES[variant]} opacity-40 cursor-not-allowed`;
+}
+
+export function CTAButton({
+  variant = "primary",
+  href,
+  children,
+  description,
+  external = false,
+}: CTAButtonProps) {
+  // href が undefined / 空文字の場合は「準備中」として無効化
+  const isDisabled = !href;
+  const className = `${BASE} ${isDisabled ? disabledClass(variant) : VARIANT_STYLES[variant]}`;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {isDisabled ? (
+        // 無効状態: <span> でレンダリングしてクリックイベントを防ぐ
+        // aria-disabled="true" でスクリーンリーダーに無効状態を伝える
+        <span
+          role="button"
+          aria-disabled="true"
+          aria-label="準備中"
+          title="準備中"
+          className={className}
+        >
+          準備中
+        </span>
+      ) : (
+        // 有効状態: <a> タグでリンクとしてレンダリング
+        <a
+          href={href}
+          className={className}
+          {...(external
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {})}
+        >
+          {children}
+        </a>
+      )}
+
+      {/* 無効時にのみ description を表示する（1行の補足説明） */}
+      {isDisabled && description && (
+        <p className="text-xs text-zinc-500 dark:text-zinc-400">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/app/_components/Hero.tsx
+++ b/app/_components/Hero.tsx
@@ -1,0 +1,117 @@
+/**
+ * Hero — ファーストビューコンポーネント
+ *
+ * 役割: ページ最上部で施設の価値と予約導線を即座に伝える。
+ *
+ * 構成:
+ *   1. 背景画像（外観写真: imgs/hero-exterior.jpg）
+ *   2. 黒の半透明オーバーレイ（文字視認性を担保）
+ *   3. キャッチコピー / サブコピー（docs/CONTENT.md 確定文言）
+ *   4. 主要 CTA（ご宿泊予約 / 準備中フォールバック）
+ *   5. ページ内ショートカット（料金・アクセス・予約）
+ *
+ * 画像最適化:
+ *   - next/image の priority prop でファーストビューの LCP を改善する
+ *     （LCP = Largest Contentful Paint: 最大要素の表示速度。SEO と UX の指標）
+ *
+ * 環境変数:
+ *   - NEXT_PUBLIC_BOOKING_URL: 未設定時は「準備中」で CTA を無効化する
+ */
+
+import Image from "next/image";
+
+import heroImage from "../../imgs/hero-exterior.jpg";
+import { anchorHref } from "../_lib/anchors";
+import { CTAButton } from "./CTAButton";
+
+// ---- コンテンツ定数（docs/CONTENT.md の確定文言を使用） ----
+
+/** h1 に載せるキャッチコピー */
+const CATCH_COPY = "海もアクティビティも観光も、遊びのベースキャンプ。";
+
+/** キャッチコピー直下のサブコピー */
+const SUB_COPY =
+  "1棟貸しの「TATEYAMA BASE 北条」。屋上テラスや1階ウッドデッキ、卓球・麻雀などの室内アクティビティも揃い、家族や仲間との滞在をアクティブに楽しめます。";
+
+/** ページ内ショートカットリンク */
+const SHORTCUTS = [
+  { label: "料金", href: anchorHref("pricing") },
+  { label: "アクセス", href: anchorHref("access") },
+  { label: "予約", href: anchorHref("booking") },
+] as const;
+
+export function Hero() {
+  // NEXT_PUBLIC_BOOKING_URL が未設定の場合は undefined になる
+  // → CTAButton に渡すと「準備中」フォールバックが動く
+  const bookingUrl = process.env.NEXT_PUBLIC_BOOKING_URL;
+
+  return (
+    <section
+      aria-label="ファーストビュー"
+      className="relative flex min-h-[480px] items-end sm:min-h-[560px]"
+    >
+      {/* ----- 背景画像 ----- */}
+      {/*
+       * fill: 親要素（relative）いっぱいに画像を広げる
+       * priority: LCP 対象のため先読みを指定
+       * object-cover: アスペクト比を保ちつつ全体を覆う
+       * sizes: レスポンシブ幅ヒント（画像最適化に使われる）
+       */}
+      <Image
+        src={heroImage}
+        alt="TATEYAMA BASE 北条 外観"
+        fill
+        priority
+        className="object-cover"
+        sizes="100vw"
+      />
+
+      {/* ----- 黒の半透明オーバーレイ ----- */}
+      {/*
+       * テキストが画像に埋もれないよう bg-black/40 で 40% の黒を重ねる
+       * （docs/DESIGN.md 3.2 より）
+       * aria-hidden: スクリーンリーダーには意味のない装飾要素なので隠す
+       */}
+      <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
+
+      {/* ----- コンテンツ（画像・オーバーレイより手前に表示） ----- */}
+      <div className="relative mx-auto w-full max-w-6xl space-y-6 px-4 py-12 sm:px-6 sm:py-16">
+        {/* キャッチコピー: h1 はページに 1 つ（docs/DESIGN.md 2.2 より） */}
+        <h1 className="max-w-2xl text-3xl font-semibold leading-snug tracking-tight text-white sm:text-4xl">
+          {CATCH_COPY}
+        </h1>
+
+        {/* サブコピー */}
+        <p className="max-w-xl text-base leading-7 text-white/90">{SUB_COPY}</p>
+
+        {/* 主要 CTA: ご宿泊予約（URL 未設定時は「準備中」） */}
+        <CTAButton
+          variant="primary"
+          href={bookingUrl}
+          external
+          description={
+            !bookingUrl ? "予約（STORES）は準備中です。" : undefined
+          }
+        >
+          ご宿泊予約
+        </CTAButton>
+
+        {/* ページ内ショートカット（Hero 直下でセクションへ飛べる） */}
+        <nav aria-label="ページ内ショートカット">
+          <ul className="flex flex-wrap gap-4">
+            {SHORTCUTS.map(({ label, href }) => (
+              <li key={href}>
+                <a
+                  href={href}
+                  className="text-sm font-medium text-white/80 underline-offset-4 hover:text-white hover:underline"
+                >
+                  {label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,41 +1,17 @@
+import { CTAButton } from "./_components/CTAButton";
+import { Hero } from "./_components/Hero";
 import { Section } from "./_components/Section";
-import { ANCHOR_IDS, anchorHref } from "./_lib/anchors";
-import { getFooterCtaItems } from "./_lib/navigation";
+import { ANCHOR_IDS } from "./_lib/anchors";
 import { SITE } from "./_lib/site";
 
 export default function Home() {
-  const ctas = getFooterCtaItems();
+  // 予約 URL が設定されているかを確認する
+  const bookingUrl = process.env.NEXT_PUBLIC_BOOKING_URL;
 
   return (
     <div className="flex flex-1 flex-col">
-      <div className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black">
-        <div className="mx-auto max-w-6xl space-y-6 px-4 py-14 sm:px-6 sm:py-16">
-          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">{SITE.name}</h1>
-          <p className="max-w-3xl text-base leading-7 text-zinc-600 dark:text-zinc-400">
-            館山駅から徒歩約9分、海まで徒歩約30秒。4〜8名で泊まれる1棟貸しの貸別荘です。
-          </p>
-          <div className="flex flex-wrap items-center gap-4">
-            <a
-              href={anchorHref("pricing")}
-              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
-            >
-              料金を見る
-            </a>
-            <a
-              href={anchorHref("access")}
-              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
-            >
-              アクセスを見る
-            </a>
-            <a
-              href={anchorHref("booking")}
-              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
-            >
-              予約・問い合わせへ
-            </a>
-          </div>
-        </div>
-      </div>
+      {/* Hero: ファーストビュー（画像・コピー・予約 CTA） */}
+      <Hero />
 
       <Section
         id={ANCHOR_IDS.pricing}
@@ -71,29 +47,17 @@ export default function Home() {
         lead="予約は外部サービス（STORES）を利用します。"
       >
         <div className="flex flex-col items-start gap-3">
-          {ctas.map((cta) =>
-            cta.disabled || !cta.href ? (
-              <span
-                key={cta.key}
-                aria-disabled="true"
-                className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-200 px-4 text-sm font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
-                title="準備中"
-              >
-                {cta.label}（準備中）
-              </span>
-            ) : (
-              <a
-                key={cta.key}
-                href={cta.href}
-                className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-900 px-4 text-sm font-medium text-white hover:opacity-90 dark:bg-zinc-50 dark:text-zinc-950"
-              >
-                {cta.label}
-              </a>
-            ),
-          )}
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            予約URLが未設定の場合は「準備中」と表示されます。
-          </p>
+          {/* CTAButton: URL 未設定時は「準備中」で自動的に無効化される */}
+          <CTAButton
+            variant="primary"
+            href={bookingUrl}
+            external
+            description={
+              !bookingUrl ? "予約（STORES）は準備中です。" : undefined
+            }
+          >
+            ご宿泊予約
+          </CTAButton>
         </div>
       </Section>
     </div>


### PR DESCRIPTION
## 概要
Issue #4 の実装。ファーストビューに Hero と予約 CTA を追加し、`NEXT_PUBLIC_BOOKING_URL` 未設定時の「準備中」フォールバックを実装した。

## 変更ファイル
| ファイル | 種別 | 内容 |
|---|---|---|
| `app/_components/CTAButton.tsx` | 新規 | Primary / Secondary / Tertiary + 無効状態 |
| `app/_components/Hero.tsx` | 新規 | 背景画像・コピー・予約 CTA・ページ内ショートカット |
| `app/page.tsx` | 変更 | インライン Hero を `<Hero />` に置き換え、booking セクション CTA を `CTAButton` に統一 |

## 受け入れ条件（AC）確認
- [x] Hero 背景画像に `imgs/hero-exterior.jpg` を使用
- [x] キャッチコピー「海もアクティビティも観光も、遊びのベースキャンプ。」（docs/CONTENT.md 確定文言）
- [x] サブコピー：1棟貸し〜アクティブに楽しめます。（docs/CONTENT.md 確定文言）
- [x] `NEXT_PUBLIC_BOOKING_URL` 未設定 → ボタン文言「準備中」＋クリック不可（`aria-disabled`）＋説明 1 行

## 動作確認手順（手動）
1. `npm run dev` を実行
2. `http://localhost:3000` を開く
3. **Hero 画像が表示される**ことを確認（外観写真・黒オーバーレイ）
4. **キャッチコピー・サブコピー**が画像の上に白文字で読めることを確認
5. 予約ボタンが「準備中」かつクリック不可、その直下に説明文 1 行があることを確認（`.env.local` に `NEXT_PUBLIC_BOOKING_URL` が未設定の状態）
6. `.env.local` に `NEXT_PUBLIC_BOOKING_URL=https://example.com` を設定して再起動 → ボタンが「ご宿泊予約」として有効になることを確認
7. スマホ幅（375px 相当）で Hero のレイアウトが崩れないことを確認

## リスク・ロールバック
- **リスク**: Hero がない旧インライン構造は削除済みのため、Hero コンポーネントが壊れるとファーストビューが消える
- **ロールバック**: `git revert HEAD` または このブランチをマージせず `main` に戻す

Closes #4