### PR TITLE
feat(#5): MVP - Pricing / Access / Booking セクション実装

### DIFF
--- a/app/_components/AccessSection.tsx
+++ b/app/_components/AccessSection.tsx
@@ -1,0 +1,108 @@
+/**
+ * AccessSection — アクセスセクション
+ *
+ * 役割: 住所・地図リンク・交通手段を表示し、初めて訪れるユーザーの不安を取り除く。
+ *
+ * 構成:
+ *   1. 住所（郵便番号+住所）
+ *   2. 地図 CTA（Googleマップ）
+ *      - NEXT_PUBLIC_MAP_URL 未設定時は「準備中」で無効化
+ *   3. 最寄り情報（駅・海）
+ *   4. 交通手段
+ *
+ * データの根拠: docs/FACTS.md（確定情報のみ）
+ * 環境変数: NEXT_PUBLIC_MAP_URL（未設定時は地図 CTA が「準備中」）
+ */
+
+import { ANCHOR_IDS } from "../_lib/anchors";
+import { SITE } from "../_lib/site";
+import { CTAButton } from "./CTAButton";
+import { Section } from "./Section";
+
+// ---- 確定情報（docs/FACTS.md より） ----
+
+/** 最寄り情報（数値は一次情報に基づき「約」を付ける） */
+const NEARBY = [
+  { label: "海（北条海岸）", detail: "徒歩約30秒" },
+  { label: "館山駅", detail: "徒歩約9分" },
+];
+
+/** 交通手段（確定済み） */
+const TRANSPORT_OPTIONS = ["車", "電車", "バス", "高速ジェット", "フェリー"];
+
+export function AccessSection() {
+  return (
+    // id="access" を設定して、ヘッダーや他セクションの「アクセス」リンクから到達できるようにする
+    <Section
+      id={ANCHOR_IDS.access}
+      title="アクセス"
+      lead="館山駅から徒歩圏内。海まで徒歩約30秒の好立地です。"
+    >
+      {/* ---- 住所 + 地図 CTA ---- */}
+      <div className="space-y-4 rounded-xl border border-zinc-200 bg-zinc-50 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
+        {/* 住所 */}
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            住所
+          </p>
+          <p className="mt-1 text-base font-medium text-zinc-900 dark:text-zinc-50">
+            {SITE.address}
+          </p>
+        </div>
+
+        {/*
+         * 地図 CTA
+         * CTAButton に SITE.mapUrl を渡す。
+         * undefined（NEXT_PUBLIC_MAP_URL 未設定）の場合は CTAButton が自動で「準備中」に切り替える。
+         * variant="tertiary": 地図リンクは補助的な行動（テキストリンク風）
+         */}
+        <CTAButton
+          variant="tertiary"
+          href={SITE.mapUrl}
+          external
+          description={!SITE.mapUrl ? "地図リンクは準備中です。" : undefined}
+        >
+          Googleマップで開く
+        </CTAButton>
+      </div>
+
+      {/* ---- 最寄り情報 ---- */}
+      <div>
+        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          最寄り
+        </h3>
+        {/* dl（definition list）: 名称と補足をペアで表現するセマンティックな要素 */}
+        <dl className="mt-3 space-y-2">
+          {NEARBY.map((item) => (
+            <div key={item.label} className="flex items-baseline gap-3">
+              <dt className="w-28 shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                {item.label}
+              </dt>
+              <dd className="text-sm text-zinc-600 dark:text-zinc-400">
+                {item.detail}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {/* ---- 交通手段 ---- */}
+      <div>
+        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          交通手段
+        </h3>
+        {/* flex-wrap: 要素数が多い場合に自動で折り返す */}
+        <div className="mt-3 flex flex-wrap gap-2">
+          {TRANSPORT_OPTIONS.map((option) => (
+            <span
+              key={option}
+              className="rounded-full border border-zinc-200 px-3 py-1 text-sm text-zinc-700 dark:border-zinc-700 dark:text-zinc-300"
+            >
+              {option}
+            </span>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/app/_components/PricingSection.tsx
+++ b/app/_components/PricingSection.tsx
@@ -1,0 +1,305 @@
+/**
+ * PricingSection — 料金セクション
+ *
+ * 役割: シーズン別・人数別の宿泊料金、キャンセルポリシー、レンタル料金を表示する。
+ *
+ * 構成:
+ *   1. 料金サマリー（最安値・前提を一目で把握）＋「料金を見る」アンカー導線
+ *   2. 詳細料金表（シーズン × 宿泊人数）
+ *   3. キャンセルポリシー
+ *   4. レンタル料金
+ *
+ * データの根拠: docs/FACTS.md（確定情報のみ）
+ */
+
+import { ANCHOR_IDS } from "../_lib/anchors";
+import { Section } from "./Section";
+
+// ---- 料金データ（docs/FACTS.md の確定値をそのまま使用） ----
+// ※ 計算式（base + extra × count）だと端数が合わないため、絶対値で管理する
+
+/** 1 行分の宿泊人数データ */
+type PriceRow = {
+  /** 宿泊人数 */
+  guests: number;
+  /** 使用フロアの補足 */
+  note: string;
+  /**
+   * シーズン別の料金（円）
+   * offseason: オフシーズン
+   * regular:   レギュラーシーズン
+   * high:      ハイシーズン
+   * top:       トップシーズン
+   */
+  prices: {
+    offseason: number;
+    regular: number;
+    high: number;
+    top: number;
+  };
+};
+
+/** 宿泊料金テーブル（清掃費込み） */
+const PRICING_ROWS: PriceRow[] = [
+  {
+    guests: 4,
+    note: "1階のみ",
+    prices: { offseason: 46000, regular: 53000, high: 58000, top: 63000 },
+  },
+  {
+    guests: 5,
+    note: "1・2階",
+    prices: { offseason: 48500, regular: 56500, high: 61500, top: 66500 },
+  },
+  {
+    guests: 6,
+    note: "1・2階",
+    prices: { offseason: 51000, regular: 60000, high: 65000, top: 70000 },
+  },
+  {
+    guests: 7,
+    note: "1・2階",
+    prices: { offseason: 53500, regular: 63500, high: 68500, top: 73500 },
+  },
+  {
+    guests: 8,
+    note: "1・2階",
+    prices: { offseason: 56000, regular: 67000, high: 72000, top: 77000 },
+  },
+];
+
+/** シーズン定義（列ヘッダーと期間説明） */
+const SEASONS = [
+  { key: "offseason" as const, label: "オフシーズン", description: "左記以外" },
+  {
+    key: "regular" as const,
+    label: "レギュラー",
+    description: "日祝・春休み（土曜・祝前日・3連休2日目・7〜9月除く）",
+  },
+  {
+    key: "high" as const,
+    label: "ハイ",
+    description: "土曜・祝前日・3連休2日目・7/10〜9/10（お盆除く）",
+  },
+  {
+    key: "top" as const,
+    label: "トップ",
+    description: "GW・お盆・シルバーウィーク・年末年始（12/28〜1/7）は都度設定",
+  },
+];
+
+/** キャンセルポリシー */
+const CANCELLATION_RULES = [
+  { timing: "7日〜3日前", rate: "ご利用料の30%" },
+  { timing: "2日〜1日前", rate: "ご利用料の50%" },
+  { timing: "当日", rate: "ご利用料の100%" },
+];
+
+/** レンタル料金 */
+const RENTAL_ITEMS = [
+  {
+    name: "サップ（ウェットスーツ＋ライフジャケット付き・2人乗り）",
+    note: "重量 100 ㎏ まで / 1日",
+    rows: [
+      { label: "1台", price: 3000 },
+      { label: "2台", price: 5000 },
+      { label: "3台", price: 7000 },
+      { label: "4台", price: 9000 },
+    ],
+  },
+  {
+    name: "ウェットスーツのみ",
+    rows: [{ label: "1着", price: 1000 }],
+  },
+  {
+    name: "ライフジャケットのみ",
+    rows: [{ label: "1着", price: 1000 }],
+  },
+];
+
+/** 数値を円表示にフォーマットする（例: 46000 → "¥46,000"） */
+function yen(amount: number): string {
+  return `¥${amount.toLocaleString("ja-JP")}`;
+}
+
+export function PricingSection() {
+  return (
+    // id="pricing" を設定して、ヘッダーや他セクションの「料金」リンクから到達できるようにする
+    <Section
+      id={ANCHOR_IDS.pricing}
+      title="料金"
+      lead="清掃費込み。宿泊人数とシーズンによって料金が変わります。"
+    >
+      {/* ---- 1. 料金サマリー ---- */}
+      {/* ページ上部から「料金を見る → #pricing」で到達した際に最短で要点を把握できるようにする */}
+      <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
+        <p className="text-sm font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+          料金はじめに
+        </p>
+        <ul className="mt-3 space-y-2 text-sm leading-6 text-zinc-700 dark:text-zinc-300">
+          <li>
+            <span className="font-medium">最安：オフシーズン 4名まで</span>
+            &nbsp;— ¥46,000（清掃費込み）
+          </li>
+          <li>
+            <span className="font-medium">宿泊人数：</span>4〜8名
+          </li>
+          <li>
+            <span className="font-medium">シーズン区分：</span>
+            オフ / レギュラー / ハイ / トップ（4段階）
+          </li>
+          <li>
+            <span className="font-medium">トップシーズン：</span>
+            GW・お盆・シルバーウィーク・年末年始は都度設定
+          </li>
+        </ul>
+        <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+          ※ 詳細は下記の料金表をご確認ください。
+        </p>
+      </div>
+
+      {/* ---- 2. 詳細料金表 ---- */}
+      {/* overflow-x-auto: スマホでも横スクロールで表全体を確認できる */}
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[520px] border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-zinc-200 dark:border-zinc-700">
+              {/* 人数列 */}
+              <th className="py-3 pr-4 text-left font-semibold text-zinc-900 dark:text-zinc-50">
+                人数
+              </th>
+              {/* シーズン列（4列） */}
+              {SEASONS.map((s) => (
+                <th
+                  key={s.key}
+                  className="px-3 py-3 text-right font-semibold text-zinc-900 dark:text-zinc-50"
+                >
+                  {s.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {PRICING_ROWS.map((row) => (
+              <tr
+                key={row.guests}
+                className="border-b border-zinc-100 last:border-0 dark:border-zinc-800"
+              >
+                {/* 人数 + 使用フロア注記 */}
+                <td className="py-3 pr-4 text-zinc-900 dark:text-zinc-50">
+                  <span className="font-medium">{row.guests}名</span>
+                  <span className="ml-1.5 text-xs text-zinc-500 dark:text-zinc-400">
+                    ({row.note})
+                  </span>
+                </td>
+                {/* シーズン別料金 */}
+                {SEASONS.map((s) => (
+                  <td
+                    key={s.key}
+                    className="px-3 py-3 text-right tabular-nums text-zinc-700 dark:text-zinc-300"
+                  >
+                    {yen(row.prices[s.key])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* シーズン定義の補足 */}
+      <div className="space-y-1">
+        <p className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+          シーズン区分の目安
+        </p>
+        <ul className="space-y-1">
+          {SEASONS.map((s) => (
+            <li
+              key={s.key}
+              className="text-xs leading-5 text-zinc-500 dark:text-zinc-400"
+            >
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {s.label}：
+              </span>
+              {s.description}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* ---- 3. キャンセルポリシー ---- */}
+      <div>
+        {/* headingLevel=3: Section の h2 "料金" の下に位置する小見出し */}
+        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          キャンセルポリシー
+        </h3>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[280px] border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-zinc-200 dark:border-zinc-700">
+                <th className="py-2 pr-4 text-left font-semibold text-zinc-900 dark:text-zinc-50">
+                  キャンセル時期
+                </th>
+                <th className="py-2 text-right font-semibold text-zinc-900 dark:text-zinc-50">
+                  キャンセル料
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {CANCELLATION_RULES.map((rule) => (
+                <tr
+                  key={rule.timing}
+                  className="border-b border-zinc-100 last:border-0 dark:border-zinc-800"
+                >
+                  <td className="py-2 pr-4 text-zinc-700 dark:text-zinc-300">
+                    {rule.timing}
+                  </td>
+                  <td className="py-2 text-right text-zinc-700 dark:text-zinc-300">
+                    {rule.rate}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ---- 4. レンタル料金 ---- */}
+      <div>
+        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          レンタル料金
+        </h3>
+        <div className="mt-4 space-y-5">
+          {RENTAL_ITEMS.map((item) => (
+            <div key={item.name}>
+              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                {item.name}
+              </p>
+              {item.note ? (
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {item.note}
+                </p>
+              ) : null}
+              {/* 料金行（台数 / 着数 × 金額） */}
+              <div className="mt-2 flex flex-wrap gap-3">
+                {item.rows.map((r) => (
+                  <div
+                    key={r.label}
+                    className="rounded-md border border-zinc-200 px-3 py-1.5 text-sm dark:border-zinc-700"
+                  >
+                    <span className="text-zinc-500 dark:text-zinc-400">
+                      {r.label} :{" "}
+                    </span>
+                    <span className="font-medium tabular-nums text-zinc-900 dark:text-zinc-50">
+                      {yen(r.price)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/app/_lib/site.ts
+++ b/app/_lib/site.ts
@@ -1,7 +1,15 @@
 export const SITE = {
   name: "TATEYAMA BASE 北条",
   address: "〒294-0045 千葉県館山市北条2278-3",
-  mapUrl:
-    process.env.NEXT_PUBLIC_MAP_URL ??
-    "https://maps.app.goo.gl/n8sJhzN3JK3f2L2QA",
+  /**
+   * Google Maps URL。
+   * NEXT_PUBLIC_MAP_URL 未設定時は undefined → 地図 CTA が「準備中」になる。
+   * 確定値: https://maps.app.goo.gl/n8sJhzN3JK3f2L2QA（.env.local に設定して使用）
+   */
+  mapUrl: process.env.NEXT_PUBLIC_MAP_URL,
+  /**
+   * 公式 LINE URL。
+   * NEXT_PUBLIC_LINE_URL 未設定時は undefined → LINE CTA が「準備中」になる。
+   */
+  lineUrl: process.env.NEXT_PUBLIC_LINE_URL,
 } as const;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
+import { AccessSection } from "./_components/AccessSection";
 import { CTAButton } from "./_components/CTAButton";
 import { Hero } from "./_components/Hero";
+import { PricingSection } from "./_components/PricingSection";
 import { Section } from "./_components/Section";
 import { ANCHOR_IDS } from "./_lib/anchors";
 import { SITE } from "./_lib/site";
 
 export default function Home() {
-  // 予約 URL が設定されているかを確認する
+  // 予約 URL が設定されているかを確認する（未設定時は CTAButton が「準備中」を表示）
   const bookingUrl = process.env.NEXT_PUBLIC_BOOKING_URL;
 
   return (
@@ -13,41 +15,23 @@ export default function Home() {
       {/* Hero: ファーストビュー（画像・コピー・予約 CTA） */}
       <Hero />
 
-      <Section
-        id={ANCHOR_IDS.pricing}
-        title="料金"
-        lead="料金はシーズンや人数によって変わります。詳細は順次整備します。"
-      >
-        <p className="text-base leading-7 text-zinc-600 dark:text-zinc-400">
-          MVPではまず導線と見出し構造を固定し、後続Issueで料金表を実装します。
-        </p>
-      </Section>
+      {/* Pricing: 宿泊料金・キャンセルポリシー・レンタル料金 */}
+      <PricingSection />
 
-      <Section
-        id={ANCHOR_IDS.access}
-        title="アクセス"
-        lead="住所と地図リンクは固定で掲載します。"
-      >
-        <div className="space-y-2 text-base leading-7 text-zinc-600 dark:text-zinc-400">
-          <div>{SITE.address}</div>
-          <a
-            href={SITE.mapUrl}
-            className="inline-flex text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Googleマップで開く
-          </a>
-        </div>
-      </Section>
+      {/* Access: 住所・地図 CTA・最寄り・交通手段 */}
+      <AccessSection />
 
+      {/* Booking: 予約・問い合わせ CTA（ページ下部で再掲） */}
       <Section
         id={ANCHOR_IDS.booking}
         title="予約・問い合わせ"
-        lead="予約は外部サービス（STORES）を利用します。"
+        lead="ご予約は外部サービス（STORES）から承ります。ご不明な点はお気軽に LINE でお問い合わせください。"
       >
-        <div className="flex flex-col items-start gap-3">
-          {/* CTAButton: URL 未設定時は「準備中」で自動的に無効化される */}
+        <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+          {/*
+           * 予約 CTA（最重要）
+           * NEXT_PUBLIC_BOOKING_URL 未設定時は「準備中」で自動的に無効化される
+           */}
           <CTAButton
             variant="primary"
             href={bookingUrl}
@@ -57,6 +41,21 @@ export default function Home() {
             }
           >
             ご宿泊予約
+          </CTAButton>
+
+          {/*
+           * LINE 問い合わせ CTA（補助）
+           * NEXT_PUBLIC_LINE_URL 未設定時は「準備中」で自動的に無効化される
+           */}
+          <CTAButton
+            variant="secondary"
+            href={SITE.lineUrl}
+            external
+            description={
+              !SITE.lineUrl ? "LINE は準備中です。" : undefined
+            }
+          >
+            LINEで問い合わせ
           </CTAButton>
         </div>
       </Section>


### PR DESCRIPTION
## 概要
Issue #5「MVP: 主要セクション（Pricing / Access / Booking）」を実装しました。
予約判断に必要な情報（料金・アクセス）と行動（予約・問い合わせ）をページ上に揃えます。

## 変更ファイル

| ファイル | 種別 | 概要 |
|---|---|---|
| `app/_components/PricingSection.tsx` | 新規 | 料金サマリー・詳細料金表・キャンセル・レンタル |
| `app/_components/AccessSection.tsx` | 新規 | 住所・地図CTA・最寄り・交通手段 |
| `app/_lib/site.ts` | 変更 | `mapUrl` を env var 単体に変更、`lineUrl` 追加 |
| `app/page.tsx` | 変更 | 新コンポーネント組み込み＋LINE CTA 追加 |

## 受け入れ条件（AC）チェック

- [x] 料金/キャンセル/レンタルが `docs/FACTS.md` と一致（絶対値で定義、計算式なし）
- [x] `#pricing` / `#access` / `#booking` に到達できる
- [x] `NEXT_PUBLIC_MAP_URL` 未設定 → 地図 CTA「準備中」+クリック不可
- [x] `NEXT_PUBLIC_LINE_URL` 未設定 → LINE CTA「準備中」+クリック不可

## 環境変数（`.env.local` に設定してください）

```env
NEXT_PUBLIC_MAP_URL=https://maps.app.goo.gl/n8sJhzN3JK3f2L2QA
NEXT_PUBLIC_LINE_URL=（公式LINE URLが確定後に設定）
```

## 手動確認手順

1. `npm run dev` を起動
2. `http://localhost:3000/#pricing` → 料金表・キャンセル・レンタルが表示される
3. `http://localhost:3000/#access` → 住所・地図CTA・交通手段が表示される
4. `http://localhost:3000/#booking` → 予約ボタン・LINE ボタンが表示される
5. `NEXT_PUBLIC_MAP_URL` を未設定にして起動 → 地図ボタンが「準備中」+クリック不可
6. `NEXT_PUBLIC_LINE_URL` を未設定にして起動 → LINE ボタンが「準備中」+クリック不可

## リスクとロールバック

- リスク：`site.ts` の `mapUrl` ハードコードを削除したため、`.env.local` に `NEXT_PUBLIC_MAP_URL` を設定しないと地図 CTA が「準備中」表示になります（意図通り）。
- ロールバック：`git revert <commit>` または `git checkout main` で即座に戻せます。

Closes #5