### PR TITLE
feat: MVP ギャラリー + Lightbox（アクセシビリティ要件込み）#6

### DIFF
--- a/app/_components/GallerySection.tsx
+++ b/app/_components/GallerySection.tsx
@@ -1,0 +1,267 @@
+/**
+ * GallerySection — カテゴリ別ギャラリーコンポーネント
+ *
+ * 役割: 写真をカテゴリ別に並べ、タップで Lightbox を開いて滞在イメージを補強する。
+ *
+ * 設計方針（docs/DESIGN.md 3.3 / 8.5 より）:
+ *   - サムネイルは同比率（aspect-[4/3]）で揃える（ガタつきを避ける）
+ *   - カテゴリ（h3）でグループ化して情報を整理する
+ *   - 画像の alt は docs/ASSETS.md の案をベースに付与する
+ *
+ * alt 付与ルール（docs/DESIGN.md 3.4 より）:
+ *   - 意味のある写真は内容が分かる短い説明を書く
+ *   - 装飾目的のみの画像は空文字 "" にして読み上げをスキップ
+ */
+
+"use client";
+
+import Image from "next/image";
+import { useCallback, useRef, useState } from "react";
+
+// ---- 画像の import ----
+// next/image が静的に解析できるよう個別にインポートする
+import bathRoomImg from "../../imgs/bath-room.jpg";
+import bedImg from "../../imgs/bed.jpg";
+import firstFloorToiletImg from "../../imgs/first-floor-toilet.jpg";
+import firstFloorImg from "../../imgs/first-floor.jpg";
+import lifeJacketImg from "../../imgs/life-jacket.jpg";
+import livingImg from "../../imgs/living.jpg";
+import mahJonggImg from "../../imgs/mah-jongg.jpg";
+import outdoorShowerImg from "../../imgs/outdoor-shower.jpg";
+import rooftopTerraceImg from "../../imgs/rooftop-terrace.jpg";
+import sapImg from "../../imgs/sap.jpg";
+import secondFloorToiletImg from "../../imgs/second-floor-toilet.jpg";
+import secondFloorImg from "../../imgs/second-floor.jpg";
+import tableTennisImg from "../../imgs/table-tennis.jpg";
+import wetSuitImg from "../../imgs/wet-suit.jpg";
+import woodTerraceImg from "../../imgs/wood-terrace.jpg";
+import { type LightboxImage, Lightbox } from "./Lightbox";
+
+// ----------------------------------------------------------------
+// カテゴリ定義
+// ----------------------------------------------------------------
+
+/**
+ * ギャラリーの 1 カテゴリ
+ * title: カテゴリ名（h3 で表示する）
+ * images: そのカテゴリの画像一覧
+ */
+type GalleryCategory = {
+  title: string;
+  images: LightboxImage[];
+};
+
+/** カテゴリ別の画像データ（docs/ASSETS.md の alt 案をベースに設定）*/
+const GALLERY_CATEGORIES: GalleryCategory[] = [
+  {
+    title: "室内",
+    images: [
+      { src: firstFloorImg, alt: "1階の室内の様子" },
+      { src: livingImg, alt: "リビングの様子" },
+      { src: bedImg, alt: "ベッドの様子" },
+      { src: secondFloorImg, alt: "2階の室内の様子" },
+    ],
+  },
+  {
+    title: "テラス・屋外",
+    images: [
+      { src: woodTerraceImg, alt: "1階ウッドデッキの様子" },
+      { src: rooftopTerraceImg, alt: "屋上テラスの様子" },
+      { src: outdoorShowerImg, alt: "屋外シャワーの様子" },
+    ],
+  },
+  {
+    title: "水まわり",
+    images: [
+      { src: bathRoomImg, alt: "バスルームの様子" },
+      { src: firstFloorToiletImg, alt: "1階トイレの様子" },
+      { src: secondFloorToiletImg, alt: "2階トイレの様子" },
+    ],
+  },
+  {
+    title: "アクティビティ",
+    images: [
+      { src: tableTennisImg, alt: "卓球台の様子" },
+      { src: mahJonggImg, alt: "麻雀台の様子" },
+    ],
+  },
+  {
+    title: "レンタル用品",
+    images: [
+      { src: sapImg, alt: "サップ（レンタル用品）の様子" },
+      { src: wetSuitImg, alt: "ウェットスーツ（レンタル用品）の様子" },
+      { src: lifeJacketImg, alt: "ライフジャケット（レンタル用品）の様子" },
+    ],
+  },
+];
+
+/**
+ * カテゴリをまたいだ「全画像のフラット配列」を生成する。
+ * Lightbox に渡す globalIndex（全体通し番号）の計算に使う。
+ *
+ * 例: カテゴリ A に 4 枚, カテゴリ B に 3 枚ある場合
+ *   → [A[0], A[1], A[2], A[3], B[0], B[1], B[2]] の順番で配列を作る
+ */
+const ALL_IMAGES: LightboxImage[] = GALLERY_CATEGORIES.flatMap(
+  (cat) => cat.images,
+);
+
+// ----------------------------------------------------------------
+// コンポーネント
+// ----------------------------------------------------------------
+
+export function GallerySection() {
+  /**
+   * Lightbox で表示中の画像インデックス（全体通し番号）
+   * null = 非表示
+   */
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  /**
+   * 「開いたときのサムネイルボタン」への参照
+   * Lightbox を閉じたときにここへフォーカスを戻す（フォーカス復帰）
+   */
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  // ---- Lightbox を開く ----
+  // クリックされたサムネイルのボタン要素と全体インデックスを保存する
+  const openLightbox = useCallback(
+    (globalIndex: number, buttonEl: HTMLButtonElement) => {
+      triggerRef.current = buttonEl;
+      setLightboxIndex(globalIndex);
+    },
+    [],
+  );
+
+  // ---- Lightbox を閉じる ----
+  // 非表示にしてから、開いた元ボタンにフォーカスを戻す（フォーカス復帰）
+  const closeLightbox = useCallback(() => {
+    setLightboxIndex(null);
+    requestAnimationFrame(() => {
+      triggerRef.current?.focus();
+    });
+  }, []);
+
+  // ---- 次へ ----
+  const goNext = useCallback(() => {
+    setLightboxIndex((prev) => {
+      if (prev === null || prev >= ALL_IMAGES.length - 1) return prev;
+      return prev + 1;
+    });
+  }, []);
+
+  // ---- 前へ ----
+  const goPrev = useCallback(() => {
+    setLightboxIndex((prev) => {
+      if (prev === null || prev <= 0) return prev;
+      return prev - 1;
+    });
+  }, []);
+
+  // ---- カテゴリごとの先頭グローバルインデックスを事前計算 ----
+  // 例: [0, 4, 7, 10, 12] のようなオフセット配列を作る
+  const categoryOffsets = GALLERY_CATEGORIES.reduce<number[]>(
+    (acc, cat, idx) => {
+      if (idx === 0) return [0];
+      return [...acc, acc[idx - 1] + GALLERY_CATEGORIES[idx - 1].images.length];
+    },
+    [],
+  );
+
+  return (
+    <>
+      {/* ---- セクション全体 ---- */}
+      <section id="gallery" className="py-12 sm:py-16">
+        <div className="mx-auto max-w-6xl space-y-10 px-4 sm:px-6">
+          {/* ---- セクションヘッダー ---- */}
+          <header className="space-y-2">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900">
+              ギャラリー
+            </h2>
+            <p className="max-w-3xl text-base leading-7 text-slate-600">
+              施設内外の写真でご滞在のイメージをご確認ください。写真をタップすると拡大表示します。
+            </p>
+          </header>
+
+          {/* ---- カテゴリ別グリッド ---- */}
+          {GALLERY_CATEGORIES.map((category, catIdx) => (
+            <div key={category.title} className="space-y-4">
+              {/*
+               * カテゴリ見出し（h3）
+               * h2（セクション）→ h3（カテゴリ）で階層を崩さない（docs/DESIGN.md 2.2 より）
+               */}
+              <h3 className="text-xl font-semibold text-slate-900">
+                {category.title}
+              </h3>
+
+              {/*
+               * サムネイルグリッド
+               * - スマホ: 2列
+               * - sm 以上: 3〜4列
+               */}
+              <ul
+                className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 md:grid-cols-4"
+                role="list"
+                aria-label={`${category.title}の写真`}
+              >
+                {category.images.map((image, imgIdx) => {
+                  // カテゴリ内インデックス → 全体インデックス に変換
+                  const globalIndex = categoryOffsets[catIdx] + imgIdx;
+
+                  return (
+                    <li key={globalIndex}>
+                      {/*
+                       * サムネイルボタン
+                       * - button 要素にすることでキーボード操作（Enter/Space）と
+                       *   スクリーンリーダーの「クリック可能」通知を担保する
+                       * - aspect-[4/3]: 同比率でサムネイルを揃える（docs/DESIGN.md 8.5 より）
+                       */}
+                      <button
+                        type="button"
+                        aria-label={`${image.alt}（クリックで拡大）`}
+                        className="group relative block w-full overflow-hidden rounded-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+                        onClick={(e) =>
+                          openLightbox(
+                            globalIndex,
+                            e.currentTarget,
+                          )
+                        }
+                      >
+                        {/*
+                         * aspect-[4/3]: 縦横比 4:3 を固定してガタつきを防ぐ
+                         * relative: next/image の fill 配置に必要な親要素の position
+                         * group-hover のスケールでホバー時に拡大演出を付ける
+                         */}
+                        <div className="relative aspect-[4/3]">
+                          <Image
+                            src={image.src}
+                            alt={image.alt}
+                            fill
+                            className="object-cover transition-transform duration-300 group-hover:scale-105"
+                            sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
+                          />
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/*
+       * Lightbox
+       * currentIndex が null のときは内部で何もレンダリングしない
+       */}
+      <Lightbox
+        images={ALL_IMAGES}
+        currentIndex={lightboxIndex}
+        onClose={closeLightbox}
+        onNext={goNext}
+        onPrev={goPrev}
+      />
+    </>
+  );
+}

--- a/app/_components/Hero.tsx
+++ b/app/_components/Hero.tsx
@@ -35,6 +35,7 @@ const SUB_COPY =
 
 /** ページ内ショートカットリンク */
 const SHORTCUTS = [
+  { label: "ギャラリー", href: anchorHref("gallery") },
   { label: "料金", href: anchorHref("pricing") },
   { label: "アクセス", href: anchorHref("access") },
   { label: "予約", href: anchorHref("booking") },

--- a/app/_components/Lightbox.tsx
+++ b/app/_components/Lightbox.tsx
@@ -1,0 +1,280 @@
+/**
+ * Lightbox — 画像拡大表示モーダルコンポーネント
+ *
+ * 役割: サムネイルをクリックした画像を全画面で拡大表示する。
+ *
+ * アクセシビリティ要件（docs/DESIGN.md 8.6 より）:
+ *   - × / Esc / 背景クリックで閉じる
+ *   - 次へ / 前へ（ボタン + ← / →）
+ *   - フォーカストラップ（モーダル内に Tab 移動を閉じ込める）
+ *   - フォーカス復帰（閉じたとき開いた元のサムネイルにフォーカスを戻す）
+ *   - 背景スクロール停止（body scroll lock）
+ *   - role="dialog" + aria-modal="true"
+ *
+ * 用語:
+ *   - フォーカストラップ: モーダル表示中に Tab で移動しても外へ焦点が逃げない仕組み。
+ *   - フォーカス復帰: モーダルを閉じた後、開いた元の要素へ焦点を戻すこと。
+ *   - body scroll lock: モーダル表示中に背景がスクロールしないよう body に overflow-hidden をあてること。
+ */
+
+"use client";
+
+import Image, { type StaticImageData } from "next/image";
+import { useCallback, useEffect, useRef } from "react";
+
+// ----------------------------------------------------------------
+// 型定義
+// ----------------------------------------------------------------
+
+/** ライトボックスに渡す 1 枚分のデータ */
+export type LightboxImage = {
+  src: StaticImageData | string;
+  alt: string;
+};
+
+type Props = {
+  /** 表示する画像の配列 */
+  images: LightboxImage[];
+  /** 現在表示中のインデックス（null = 非表示） */
+  currentIndex: number | null;
+  /** 閉じる操作が発生したときに呼ぶコールバック */
+  onClose: () => void;
+  /** 次へ操作が発生したときに呼ぶコールバック */
+  onNext: () => void;
+  /** 前へ操作が発生したときに呼ぶコールバック */
+  onPrev: () => void;
+};
+
+// ----------------------------------------------------------------
+// コンポーネント
+// ----------------------------------------------------------------
+
+export function Lightbox({
+  images,
+  currentIndex,
+  onClose,
+  onNext,
+  onPrev,
+}: Props) {
+  /** ダイアログ要素への参照（フォーカストラップに使用） */
+  const dialogRef = useRef<HTMLDivElement>(null);
+  /** 閉じるボタンへの参照（開いたとき最初にフォーカスをあてる） */
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // 現在の画像情報
+  const isOpen = currentIndex !== null;
+  const current = isOpen ? images[currentIndex] : null;
+  const isFirst = currentIndex === 0;
+  const isLast = currentIndex !== null && currentIndex === images.length - 1;
+
+  // ---- 背景スクロール停止 ----
+  // モーダルが開いている間 body に overflow-hidden をあててスクロールを止める
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    // クリーンアップ: コンポーネント破棄時にも元に戻す
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  // ---- 開いたときにフォーカスを閉じるボタンへ移動 ----
+  useEffect(() => {
+    if (isOpen) {
+      // レンダリング後に DOM が確定してからフォーカスをあてる
+      requestAnimationFrame(() => {
+        closeButtonRef.current?.focus();
+      });
+    }
+  }, [isOpen]);
+
+  // ---- キーボード操作 ----
+  // Esc: 閉じる / ArrowRight: 次へ / ArrowLeft: 前へ
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+          onClose();
+          break;
+        case "ArrowRight":
+          if (!isLast) onNext();
+          break;
+        case "ArrowLeft":
+          if (!isFirst) onPrev();
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, isFirst, isLast, onClose, onNext, onPrev]);
+
+  // ---- フォーカストラップ ----
+  // Tab / Shift+Tab でフォーカスがモーダル外へ逃げないようにする
+  const handleKeyDownTrap = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== "Tab") return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    // フォーカス可能な要素を取得（disabled な要素を除く）
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey) {
+      // Shift+Tab: 先頭にいたら末尾へ折り返す
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      // Tab: 末尾にいたら先頭へ折り返す
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }, []);
+
+  // ---- 背景クリック処理 ----
+  // オーバーレイのみクリックで閉じる（画像部分のクリックは通過させない）
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  // 非表示のときは何もレンダリングしない（DOM に残さない）
+  if (!isOpen || !current) return null;
+
+  return (
+    /*
+     * ライトボックスのオーバーレイ（背景）
+     * - fixed inset-0: 画面全体を覆う
+     * - z-50: 他のすべての要素より手前に表示する
+     * - role="dialog" + aria-modal="true": スクリーンリーダーにダイアログとして伝える
+     */
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="画像の拡大表示"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDownTrap}
+    >
+      {/* ---- 閉じるボタン（右上） ---- */}
+      <button
+        ref={closeButtonRef}
+        aria-label="閉じる"
+        onClick={onClose}
+        className="absolute right-4 top-4 flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white transition-colors hover:bg-white/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+      >
+        {/* × のアイコン（SVG）*/}
+        <svg
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-5 w-5"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+
+      {/* ---- 前へボタン（左） ---- */}
+      <button
+        aria-label="前の写真"
+        onClick={onPrev}
+        disabled={isFirst}
+        className="absolute left-2 top-1/2 -translate-y-1/2 flex h-12 w-12 items-center justify-center rounded-full bg-white/20 text-white transition-colors hover:bg-white/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:opacity-30 sm:left-4"
+      >
+        <svg
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-6 w-6"
+        >
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+
+      {/* ---- 拡大画像エリア ---- */}
+      {/*
+       * オーバーレイをクリックしても閉じないよう e.stopPropagation() を使う
+       * （handleBackdropClick は e.target === e.currentTarget でオーバーレイのみ閉じる設計だが、
+       *   明示的に停止することで意図を明確にする）
+       */}
+      <div
+        className="relative mx-4 max-h-[90vh] w-full max-w-4xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Image
+          key={currentIndex} // インデックス変化でアニメーションをリセット
+          src={current.src}
+          alt={current.alt}
+          width={1200}
+          height={800}
+          className="mx-auto max-h-[90vh] w-auto rounded-xl object-contain shadow-2xl"
+          sizes="(max-width: 768px) 100vw, 80vw"
+        />
+
+        {/* ---- カウンター（現在位置 / 合計） ---- */}
+        <p
+          aria-live="polite"
+          className="mt-3 text-center text-sm text-white/70"
+        >
+          {currentIndex + 1} / {images.length}
+        </p>
+      </div>
+
+      {/* ---- 次へボタン（右） ---- */}
+      <button
+        aria-label="次の写真"
+        onClick={onNext}
+        disabled={isLast}
+        className="absolute right-2 top-1/2 -translate-y-1/2 flex h-12 w-12 items-center justify-center rounded-full bg-white/20 text-white transition-colors hover:bg-white/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:opacity-30 sm:right-4"
+      >
+        <svg
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-6 w-6"
+        >
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/app/_lib/anchors.ts
+++ b/app/_lib/anchors.ts
@@ -1,4 +1,5 @@
 export const ANCHOR_IDS = {
+  gallery: "gallery",
   pricing: "pricing",
   access: "access",
   booking: "booking",

--- a/app/_lib/navigation.ts
+++ b/app/_lib/navigation.ts
@@ -1,7 +1,7 @@
 import { anchorHref } from "./anchors";
 
 export type NavItem = {
-  key: "booking" | "pricing" | "access";
+  key: "booking" | "gallery" | "pricing" | "access";
   label: string;
   href?: string;
   disabled?: boolean;
@@ -16,6 +16,11 @@ export function getHeaderNavItems(): NavItem[] {
       label: "予約",
       href: bookingUrl,
       disabled: !bookingUrl,
+    },
+    {
+      key: "gallery",
+      label: "ギャラリー",
+      href: anchorHref("gallery"),
     },
     {
       key: "pricing",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { AccessSection } from "./_components/AccessSection";
 import { CTAButton } from "./_components/CTAButton";
+import { GallerySection } from "./_components/GallerySection";
 import { Hero } from "./_components/Hero";
 import { PricingSection } from "./_components/PricingSection";
 import { Section } from "./_components/Section";
@@ -14,6 +15,9 @@ export default function Home() {
     <div className="flex flex-1 flex-col">
       {/* Hero: ファーストビュー（画像・コピー・予約 CTA） */}
       <Hero />
+
+      {/* Gallery: カテゴリ別写真ギャラリー + Lightbox */}
+      <GallerySection />
 
       {/* Pricing: 宿泊料金・キャンセルポリシー・レンタル料金 */}
       <PricingSection />

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## 概要
Issue #6 を実装。写真をカテゴリ別に表示するギャラリーと、ページ内で完結する Lightbox（拡大表示）を追加。

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `app/_components/GallerySection.tsx` | 新規：カテゴリ別ギャラリー（5カテゴリ / 15枚）|
| `app/_components/Lightbox.tsx` | 新規：ライトボックスモーダル |
| `app/_lib/anchors.ts` | `gallery` アンカーを追加 |
| `app/_lib/navigation.ts` | ヘッダーナビに「ギャラリー」を追加 |
| `app/_components/Hero.tsx` | ページ内ショートカットに「ギャラリー」を追加 |
| `app/page.tsx` | `GallerySection` を Hero の直後に組み込み |

## 受け入れ条件（AC）チェック
- [x] サムネイル比率が統一されている（`aspect-[4/3]` で全枚統一）
- [x] × で閉じる（`aria-label="閉じる"` ボタン）
- [x] `Esc` で閉じる（`keydown` イベント）
- [x] 背景クリックで閉じる（`target === currentTarget` 判定）
- [x] 次へ / 前へ ボタン（`aria-label="次の写真"/"前の写真"`）
- [x] ← / → キー操作（`ArrowLeft` / `ArrowRight`）
- [x] 先頭 / 末尾でボタン無効化（`disabled` + `opacity-30`）
- [x] フォーカストラップ（Tab/Shift+Tab をモーダル内に閉じ込める）
- [x] フォーカス復帰（閉じたとき開いた元のサムネイルへ）
- [x] 背景スクロール停止（`document.body.style.overflow = "hidden"`）
- [x] `role="dialog"` + `aria-modal="true"`
- [x] alt は `docs/ASSETS.md` の案をベースに全 15 枚付与

## カテゴリ構成
| カテゴリ | 枚数 |
|---|---|
| 室内 | 4 |
| テラス・屋外 | 3 |
| 水まわり | 3 |
| アクティビティ | 2 |
| レンタル用品 | 3 |

## 手動確認手順
1. `npm run dev` でローカル起動
2. **ギャラリー表示**：5カテゴリが見出し（h3）付きで表示されること
3. **比率統一**：全サムネイルが 4:3 比率で揃っていること
4. **Lightbox 開閉**：サムネイルをクリック → 拡大表示されること
5. **閉じる操作**：× ボタン / `Esc` / 背景クリックで閉じること
6. **ナビゲーション**：前へ/次へボタン・← / → キーで画像が切り替わること
7. **端境値**：先頭で「前へ」が無効、末尾で「次へ」が無効になること
8. **フォーカス**：Tab はモーダル内のみ移動し、閉じたら元サムネイルにフォーカスが戻ること
9. **スクロール**：Lightbox 表示中は背景がスクロールしないこと
10. **スマホ**：2カラムでサムネイルが表示されること

## リスクとロールバック手順
- **リスク**：なし（新規追加コンポーネントのみ、既存機能への副作用なし）
- **ロールバック**：`git revert` でこのコミットを取り消せば即座に元の状態へ戻せる

Closes #6