### PR TITLE
feat(#16): SummarySection — Hero 直後に要点サマリーセクションを実装

### DIFF
--- a/app/_components/SummarySection.tsx
+++ b/app/_components/SummarySection.tsx
@@ -1,0 +1,235 @@
+/**
+ * SummarySection — 要点サマリーセクション（Hero 直下）
+ *
+ * 目的: スクロールせずに「泊まれるか判断できる最小情報」をひと目で伝え、
+ *       予約決断を最短化する。
+ *
+ * 表示する情報（docs/FACTS.md の確定値）:
+ *   - 宿泊可能人数: 4〜8名
+ *   - 海まで: 徒歩約30秒
+ *   - 館山駅から: 徒歩約9分
+ *   - 住所: 〒294-0045 千葉県館山市北条2278-3
+ *
+ * デザイン準拠: docs/DESIGN.md（余白・フォント・カラールール）
+ * セマンティック: <section> + <h2> + <ul> で見出し階層を維持
+ */
+
+// ────────────────────────────────────────────────────────
+// アイコン（インライン SVG）
+// aria-hidden="true" + title なしで、装飾用として扱う
+// ────────────────────────────────────────────────────────
+
+/** 人のシルエット（宿泊人数） */
+function UsersIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* メインの人物 */}
+      <circle cx="9" cy="7" r="3" />
+      <path d="M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2" />
+      {/* サブの人物 */}
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      <path d="M21 21v-2a4 4 0 0 0-3-3.85" />
+    </svg>
+  );
+}
+
+/** 波形（海まで） */
+function WavesIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* 波の曲線 2 本 */}
+      <path d="M2 6c.6.5 1.2 1 2.5 1C7 7 7 5 9.5 5c2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
+      <path d="M2 12c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
+      <path d="M2 18c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
+    </svg>
+  );
+}
+
+/** 歩行者（徒歩時間）— 道路標識風の歩行者シルエット */
+function WalkIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* 頭 */}
+      <circle cx="12" cy="4" r="1.75" />
+      {/* 胴体（肩〜腰） */}
+      <path d="M12 7v5" />
+      {/* 腕（左右に広がる） */}
+      <path d="M9 9l3 2 3-2" />
+      {/* 脚（左脚・右脚） */}
+      <path d="M12 12l-2 6" />
+      <path d="M12 12l2.5 6" />
+    </svg>
+  );
+}
+
+/** マップピン（住所） */
+function MapPinIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* ピンの本体 */}
+      <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" />
+      {/* ピン中心の円 */}
+      <circle cx="12" cy="9" r="2.5" />
+    </svg>
+  );
+}
+
+// ────────────────────────────────────────────────────────
+// サマリーアイテムの型定義
+// ────────────────────────────────────────────────────────
+
+type SummaryItem = {
+  /** スクリーンリーダー向けのラベル（例: "宿泊可能人数"） */
+  label: string;
+  /** 表示値（例: "4〜8名"） */
+  value: string;
+  /** アイコンコンポーネント */
+  icon: React.ReactNode;
+};
+
+// ────────────────────────────────────────────────────────
+// サマリーデータ（docs/FACTS.md の確定値を使用）
+// 距離・時間の数値は「約」付き（docs/DECISIONS.md 準拠）
+// ────────────────────────────────────────────────────────
+
+const SUMMARY_ITEMS: SummaryItem[] = [
+  {
+    label: "宿泊人数",
+    value: "4〜8名",
+    icon: <UsersIcon />,
+  },
+  {
+    label: "海まで",
+    value: "徒歩約30秒",
+    icon: <WavesIcon />,
+  },
+  {
+    label: "館山駅から",
+    value: "徒歩約9分",
+    icon: <WalkIcon />,
+  },
+  {
+    label: "住所",
+    value: "〒294-0045 千葉県館山市北条2278-3",
+    icon: <MapPinIcon />,
+  },
+];
+
+// ────────────────────────────────────────────────────────
+// SummarySection コンポーネント
+// ────────────────────────────────────────────────────────
+
+export function SummarySection() {
+  return (
+    /*
+     * <section>: ARIA + セマンティック HTML
+     * id="summary": ページ内アンカー用（将来のヘッダーリンク等に対応）
+     * aria-labelledby: h2 と紐付けてセクションの意味をスクリーンリーダーに伝える
+     */
+    <section
+      id="summary"
+      aria-labelledby="summary-heading"
+      className="border-b border-slate-200 bg-slate-50 py-8 sm:py-10"
+    >
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        {/*
+         * h2: 見出し階層を守るために必須（h1=Hero, h2=各セクション）
+         * text-xl に抑えてコンパクトさを維持する
+         */}
+        <h2
+          id="summary-heading"
+          className="mb-6 text-xl font-semibold tracking-tight text-slate-900"
+        >
+          ひと目でわかること
+        </h2>
+
+        {/*
+         * <ul role="list">: 箇条書きリストとして意味を持たせる
+         * grid: モバイル 2列 → sm 以上で 4列（コンパクトレイアウト）
+         */}
+        <ul
+          role="list"
+          className="grid grid-cols-2 gap-x-4 gap-y-6 sm:grid-cols-4"
+        >
+          {SUMMARY_ITEMS.map((item) => (
+            <li key={item.label} className="flex flex-col gap-2">
+              {/*
+               * アイコン: text-slate-600 で本文より薄め
+               * サイズは 24×24 px（タッチ対象ではないため小さくてよい）
+               */}
+              <span className="text-slate-600" aria-hidden="true">
+                {item.icon}
+              </span>
+
+              {/*
+               * ラベル: 小さめのサポートテキスト（text-sm / text-slate-600）
+               * <dt> ではなく <span> にして視覚的なシンプルさを保つ
+               */}
+              <span className="text-sm leading-tight text-slate-600">
+                {item.label}
+              </span>
+
+              {/*
+               * 値: 主役テキスト（text-base / font-semibold / text-slate-900）
+               * 住所のみ text-sm に縮小して折り返しを制御
+               */}
+              <span
+                className={
+                  item.label === "住所"
+                    ? "text-sm font-semibold leading-snug text-slate-900"
+                    : "text-base font-semibold text-slate-900"
+                }
+              >
+                {item.value}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/app/_lib/anchors.ts
+++ b/app/_lib/anchors.ts
@@ -1,4 +1,5 @@
 export const ANCHOR_IDS = {
+  summary: "summary",
   gallery: "gallery",
   pricing: "pricing",
   access: "access",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { GallerySection } from "./_components/GallerySection";
 import { Hero } from "./_components/Hero";
 import { PricingSection } from "./_components/PricingSection";
 import { Section } from "./_components/Section";
+import { SummarySection } from "./_components/SummarySection";
 import { ANCHOR_IDS } from "./_lib/anchors";
 import { SITE } from "./_lib/site";
 
@@ -15,6 +16,12 @@ export default function Home() {
     <div className="flex flex-1 flex-col">
       {/* Hero: ファーストビュー（画像・コピー・予約 CTA） */}
       <Hero />
+
+      {/* Summary: 要点サマリー（Hero 直後）
+       * 宿泊人数・海まで・館山駅から・住所をひと目で伝えるセクション
+       * IA.md セクション順 2番め（Hero の直後）
+       */}
+      <SummarySection />
 
       {/* Gallery: カテゴリ別写真ギャラリー + Lightbox */}
       <GallerySection />


### PR DESCRIPTION
## 概要

Issue #16 の実装。Hero 直下に「泊まれるか判断できる最小情報」をひと目で伝えるサマリーセクション（`SummarySection`）を追加した。

## 変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `app/_components/SummarySection.tsx` | 新規 | 要点サマリーコンポーネント |
| `app/page.tsx` | 修正 | Hero 直後に SummarySection を配置 |
| `app/_lib/anchors.ts` | 修正 | `summary` アンカーを追加 |

## 実装内容

- **表示情報**（`docs/FACTS.md` の確定値を使用）
  - 宿泊可能人数：4〜8名
  - 海まで：徒歩約30秒
  - 館山駅から：徒歩約9分
  - 住所：〒294-0045 千葉県館山市北条2278-3
- **「約」の付け方**：距離・時間の数値のみ（`docs/DECISIONS.md` 準拠・`docs/FACTS.md` の確定表記に従い人数は範囲表記のまま）
- **レイアウト**：モバイル 2 列グリッド → `sm:` 以上で 4 列に展開（`py-8 sm:py-10` でコンパクト）
- **セマンティック HTML**：`<section aria-labelledby>` + `<h2>` + `<ul role="list">` + `<li>` で見出し階層を維持
- **デザイン**：`bg-slate-50`・`slate-900/600`・`max-w-6xl px-4 sm:px-6`・`font-semibold`（`docs/DESIGN.md` 準拠）
- **アイコン**：インライン SVG（`aria-hidden="true"`）で装飾のみ、追加ライブラリなし

## AC チェック

- [x] 宿泊可能人数・海まで・館山駅から・住所の 4 情報を 1 箇所にまとめて表示
- [x] 距離・時間の数値に「約」を付与（`docs/DECISIONS.md` 準拠）
- [x] スマホで 1〜2 スクロール以内に収まるコンパクトレイアウト
- [x] セマンティック HTML で実装（見出し階層を崩さない）
- [x] `docs/DESIGN.md` の余白・フォント・カラールールに準拠

## 手動確認手順

1. `npm run dev` を起動してブラウザで `http://localhost:3000` を開く
2. Hero の直下（ギャラリーの前）に白みがかった背景のセクションが表示されていることを確認
3. 「ひと目でわかること」の見出しと 4 つの要素（人数・海まで・駅から・住所）が表示されていることを確認
4. スマホ幅（375px 相当）でデベロッパーツールを使い、2 列グリッドになっていることを確認
5. タブレット幅（640px 以上）で 4 列グリッドに切り替わることを確認
6. `npm run build` が成功することを確認（型エラー・lint エラーなし）

Closes #16