### PR TITLE
feat: 特徴セクション（選ばれる理由）を追加 #17

### DIFF
--- a/app/_components/FeaturesSection.tsx
+++ b/app/_components/FeaturesSection.tsx
@@ -1,0 +1,266 @@
+/**
+ * FeaturesSection — 特徴セクション（選ばれる理由）
+ *
+ * 目的: 施設の「選ばれる理由」を言語化し、予約への動機づけを強化する。
+ *
+ * 掲載情報（docs/FACTS.md の確定情報のみ使用）:
+ *   - 1棟貸し（4〜8名）
+ *   - 屋上テラス・1階ウッドデッキ
+ *   - 室内アクティビティ（卓球・麻雀）
+ *   - レンタル用品（SUP等）
+ *   - 立地（海まで徒歩約30秒・館山駅から徒歩約9分）
+ *
+ * デザイン準拠: docs/DESIGN.md（余白・フォント・カラールール）
+ * セマンティック: <section> > <h2> > カード内 <h3> で見出し階層を維持
+ * IA.md: セクション順 4番目（料金の後・設備の前）
+ */
+
+import { ANCHOR_IDS } from "../_lib/anchors";
+import { Section } from "./Section";
+
+// ────────────────────────────────────────────────────────
+// 特徴データ（docs/FACTS.md の確定情報のみ）
+// 根拠のない断定（「最高」「No.1」等）は使わない
+// ────────────────────────────────────────────────────────
+
+type Feature = {
+  /** カード見出し（h3） */
+  title: string;
+  /** 説明文（確定情報を使用・断定表現は避ける） */
+  description: string;
+  /** アイコンコンポーネント */
+  Icon: () => React.JSX.Element;
+};
+
+// ────────────────────────────────────────────────────────
+// アイコン（インライン SVG）
+// aria-hidden="true" で装飾扱いとし、テキストで意味を伝える
+// ────────────────────────────────────────────────────────
+
+/** 家・建物アイコン（1棟貸し） */
+function HouseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* 屋根 */}
+      <path d="M3 9.5 12 3l9 6.5" />
+      {/* 建物の外壁 */}
+      <path d="M19 10v11H5V10" />
+      {/* ドア */}
+      <rect x="9" y="14" width="6" height="7" rx="0.5" />
+    </svg>
+  );
+}
+
+/** 太陽アイコン（屋上テラス・ウッドデッキ） */
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* 太陽の円 */}
+      <circle cx="12" cy="12" r="4" />
+      {/* 放射線 8本 */}
+      <path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+    </svg>
+  );
+}
+
+/** ゲーム・卓球アイコン（室内アクティビティ） */
+function TableTennisIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* ラケット（円形ヘッド） */}
+      <circle cx="9" cy="9" r="5" />
+      {/* グリップ */}
+      <line x1="13" y1="13" x2="20" y2="20" />
+      {/* ボール */}
+      <circle cx="19" cy="5" r="2" />
+    </svg>
+  );
+}
+
+/** 波・サップアイコン（レンタル用品） */
+function SurfIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* 波 2段 */}
+      <path d="M2 9c.6.5 1.2 1 2.5 1C7 10 7 8 9.5 8c2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
+      <path d="M2 15c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
+    </svg>
+  );
+}
+
+/** マップピンアイコン（立地） */
+function MapPinIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* ピン外形 */}
+      <path d="M20 10c0 6-8 13-8 13S4 16 4 10a8 8 0 1 1 16 0z" />
+      {/* 中心の丸 */}
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
+// ────────────────────────────────────────────────────────
+// 特徴リスト（docs/FACTS.md の確定情報のみ）
+// ────────────────────────────────────────────────────────
+
+/**
+ * 「選ばれる理由」5項目
+ * すべて docs/FACTS.md の確定情報に基づく。
+ * 「最高」「No.1」などの根拠なき断定は含まない。
+ */
+const FEATURES: Feature[] = [
+  {
+    title: "1棟貸し（4〜8名）",
+    description:
+      "グループや家族で全館を独占できる貸別荘です。人数に合わせて1階のみ、または1・2階の両フロアを使えます。",
+    Icon: HouseIcon,
+  },
+  {
+    title: "屋上テラス・1階ウッドデッキ",
+    description:
+      "屋外スペースを2か所確保。海風を感じながらくつろいだり、空を眺めたりと、室内とは違う時間を過ごせます。",
+    Icon: SunIcon,
+  },
+  {
+    title: "室内アクティビティ（卓球・麻雀）",
+    description:
+      "天気に左右されず楽しめる卓球台・麻雀台を2階に完備。滞在中に「やることが尽きない」工夫があります。",
+    Icon: TableTennisIcon,
+  },
+  {
+    title: "レンタル用品（SUP等）",
+    description:
+      "SUPをはじめとするレンタル用品を用意しています。海でのアクティビティを手ぶらで楽しみたい方に向いています。",
+    Icon: SurfIcon,
+  },
+  {
+    title: "海まで徒歩約30秒・館山駅から徒歩約9分",
+    description:
+      "北条海岸まで徒歩約30秒の好立地です。館山駅からも徒歩約9分でアクセスでき、車なしでも動きやすい環境です。",
+    Icon: MapPinIcon,
+  },
+];
+
+// ────────────────────────────────────────────────────────
+// 特徴カード（1枚のカードを表示するコンポーネント）
+// ────────────────────────────────────────────────────────
+
+/**
+ * FeatureCard — 個別の特徴を1枚のカードとして表示する
+ *
+ * 構成: アイコン（装飾）→ h3 見出し → 説明文
+ * デザイン: bg-slate-50 / rounded-xl / shadow-sm（docs/DESIGN.md §8.5）
+ */
+function FeatureCard({ title, description, Icon }: Feature) {
+  return (
+    <article className="flex flex-col gap-4 rounded-xl bg-slate-50 p-6 shadow-sm dark:bg-zinc-800">
+      {/* アイコン（装飾用。aria-hidden で読み上げをスキップ） */}
+      <div
+        aria-hidden="true"
+        className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-slate-700 shadow-sm dark:bg-zinc-700 dark:text-slate-300"
+      >
+        <Icon />
+      </div>
+      {/*
+       * h3: Section（h2）の下に置くことで見出し階層を維持する
+       * docs/DESIGN.md §2.2 「階層を飛ばさない」
+       */}
+      <h3 className="text-lg font-semibold leading-snug text-slate-900 dark:text-zinc-50">
+        {title}
+      </h3>
+      {/* 説明文: text-base / leading-7 で読みやすい行間を確保 */}
+      <p className="text-base leading-7 text-slate-600 dark:text-zinc-400">
+        {description}
+      </p>
+    </article>
+  );
+}
+
+// ────────────────────────────────────────────────────────
+// FeaturesSection（エクスポートするメインコンポーネント）
+// ────────────────────────────────────────────────────────
+
+/**
+ * FeaturesSection — 特徴セクション（選ばれる理由）
+ *
+ * IA.md セクション順 4番目（料金の後・設備の前）。
+ * Section コンポーネントを使うことでセクション間の余白・見出しスタイルを統一する。
+ */
+export function FeaturesSection() {
+  return (
+    <Section
+      id={ANCHOR_IDS.features}
+      title="選ばれる理由"
+      lead="TATEYAMA BASE 北条が選ばれる5つのポイントをご紹介します。"
+    >
+      {/*
+       * カードグリッド
+       * - モバイル: 1カラム
+       * - sm（640px〜）: 2カラム
+       * - lg（1024px〜）: 3カラム → 5枚 = 1行3枚 + 1行2枚
+       * list/ul を使わずグリッドのみで並べる（独立した記事として article を使用）
+       */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
+        {FEATURES.map((feature) => (
+          <FeatureCard key={feature.title} {...feature} />
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/app/_lib/anchors.ts
+++ b/app/_lib/anchors.ts
@@ -2,6 +2,7 @@ export const ANCHOR_IDS = {
   summary: "summary",
   gallery: "gallery",
   pricing: "pricing",
+  features: "features",
   access: "access",
   booking: "booking",
 } as const;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { AccessSection } from "./_components/AccessSection";
 import { CTAButton } from "./_components/CTAButton";
+import { FeaturesSection } from "./_components/FeaturesSection";
 import { GallerySection } from "./_components/GallerySection";
 import { Hero } from "./_components/Hero";
 import { PricingSection } from "./_components/PricingSection";
@@ -28,6 +29,12 @@ export default function Home() {
 
       {/* Pricing: 宿泊料金・キャンセルポリシー・レンタル料金 */}
       <PricingSection />
+
+      {/* Features: 特徴（選ばれる理由）
+       * 1棟貸し・屋上テラス・室内アクティビティ・レンタル・立地
+       * IA.md セクション順 4番め（料金の後・設備の前）
+       */}
+      <FeaturesSection />
 
       {/* Access: 住所・地図 CTA・最寄り・交通手段 */}
       <AccessSection />


### PR DESCRIPTION
## 概要

Issue #17 の実装です。施設の「選ばれる理由」を言語化した **FeaturesSection** コンポーネントを新規作成し、料金セクションの直後（IA.md セクション順 4番目）に配置しました。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/_components/FeaturesSection.tsx` | 新規作成（特徴5項目のカードグリッド） |
| `app/_lib/anchors.ts` | `features` アンカー ID を追加 |
| `app/page.tsx` | `FeaturesSection` をインポートして PricingSection の直後に配置 |

## 実装内容

- `FACTS.md` の確定情報のみを使用した5つの特徴カードを実装
  - 1棟貸し（4〜8名）
  - 屋上テラス・1階ウッドデッキ
  - 室内アクティビティ（卓球・麻雀）
  - レンタル用品（SUP等）
  - 立地（海まで徒歩約30秒・館山駅から徒歩約9分）
- 各カードにインラインSVGアイコンを配置（`aria-hidden` で装飾扱い）
- `Section` コンポーネント経由で h2 見出しを生成し、カード内に h3 を配置（階層を崩さない）

## AC 確認

- [x] FACTS.md の確定情報5項目を全て掲載
- [x] 根拠のない断定表現（「最高」「No.1」等）なし
- [x] セマンティックHTML（`section > h2 > h3`）で見出し階層を維持
- [x] DESIGN.md 準拠（`bg-slate-50 / rounded-xl / shadow-sm / text-slate-900/600 / py-12 sm:py-16`）
- [x] `page.tsx` の PricingSection 直後・AccessSection 前に配置
- [x] TypeScript エラーなし / `npm run build` 成功

## テスト

**手動確認手順**

1. `npm run dev` を起動
2. `http://localhost:3000` を開く
3. 料金セクションより下にスクロールし、「選ばれる理由」セクションが表示されることを確認
4. 5枚のカード（1棟貸し / 屋上テラス / 室内アクティビティ / レンタル / 立地）が表示されることを確認
5. スマホ幅（375px）で1カラム、タブレット幅（640px〜）で2カラム、PC幅（1024px〜）で3カラムになることを確認
6. `#features` へのアンカーリンクで当セクションに遷移できることを確認

## ロールバック手順

このPRのマージを revert するか、下記3ファイルを変更前に戻してください。
- `app/_components/FeaturesSection.tsx` を削除
- `app/_lib/anchors.ts` から `features: "features"` を削除
- `app/page.tsx` から `FeaturesSection` のインポートと配置を削除