### PR TITLE
feat: UI改善① ブランドカラー導入（zinc/slate → stone/sky 系統一）

### DIFF
--- a/app/_components/AccessSection.tsx
+++ b/app/_components/AccessSection.tsx
@@ -39,13 +39,13 @@ export function AccessSection() {
       lead="館山駅から徒歩圏内。海まで徒歩約30秒の好立地です。"
     >
       {/* ---- 住所 + 地図 CTA ---- */}
-      <div className="space-y-4 rounded-xl border border-zinc-200 bg-zinc-50 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
+      <div className="space-y-4 rounded-xl border border-stone-200 bg-stone-100 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
         {/* 住所 */}
         <div>
-          <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+          <p className="text-xs font-semibold uppercase tracking-wider text-stone-500 dark:text-zinc-400">
             住所
           </p>
-          <p className="mt-1 text-base font-medium text-zinc-900 dark:text-zinc-50">
+          <p className="mt-1 text-base font-medium text-stone-900 dark:text-zinc-50">
             {SITE.address}
           </p>
         </div>
@@ -68,17 +68,17 @@ export function AccessSection() {
 
       {/* ---- 最寄り情報 ---- */}
       <div>
-        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        <h3 className="text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50">
           最寄り
         </h3>
         {/* dl（definition list）: 名称と補足をペアで表現するセマンティックな要素 */}
         <dl className="mt-3 space-y-2">
           {NEARBY.map((item) => (
             <div key={item.label} className="flex items-baseline gap-3">
-              <dt className="w-28 shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-50">
+              <dt className="w-28 shrink-0 text-sm font-medium text-stone-900 dark:text-zinc-50">
                 {item.label}
               </dt>
-              <dd className="text-sm text-zinc-600 dark:text-zinc-400">
+              <dd className="text-sm text-stone-600 dark:text-zinc-400">
                 {item.detail}
               </dd>
             </div>
@@ -88,7 +88,7 @@ export function AccessSection() {
 
       {/* ---- 交通手段 ---- */}
       <div>
-        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        <h3 className="text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50">
           交通手段
         </h3>
         {/* flex-wrap: 要素数が多い場合に自動で折り返す */}
@@ -96,7 +96,7 @@ export function AccessSection() {
           {TRANSPORT_OPTIONS.map((option) => (
             <span
               key={option}
-              className="rounded-full border border-zinc-200 px-3 py-1 text-sm text-zinc-700 dark:border-zinc-700 dark:text-zinc-300"
+              className="rounded-full border border-stone-200 px-3 py-1 text-sm text-stone-700 dark:border-zinc-700 dark:text-zinc-300"
             >
               {option}
             </span>

--- a/app/_components/CTAButton.tsx
+++ b/app/_components/CTAButton.tsx
@@ -44,11 +44,15 @@ const BASE =
 /** 有効時の variant 別スタイル */
 const VARIANT_STYLES: Record<Variant, string> = {
   primary:
-    "bg-zinc-900 text-white hover:opacity-90 dark:bg-zinc-50 dark:text-zinc-950",
+    /*
+     * bg-sky-600: 海ブルー（Issue #23 ブランドカラー）
+     * 北条海岸の海をイメージしたプライマリ CTA
+     */
+    "bg-sky-600 text-white hover:opacity-90 dark:bg-sky-500 dark:text-white",
   secondary:
-    "border border-zinc-900 text-zinc-900 hover:opacity-80 dark:border-zinc-50 dark:text-zinc-50",
+    "border border-stone-900 text-stone-900 hover:opacity-80 dark:border-zinc-50 dark:text-zinc-50",
   tertiary:
-    "text-zinc-900 underline underline-offset-4 hover:opacity-70 dark:text-zinc-50",
+    "text-stone-900 underline underline-offset-4 hover:opacity-70 dark:text-zinc-50",
 };
 
 /**
@@ -100,7 +104,7 @@ export function CTAButton({
 
       {/* 無効時にのみ description を表示する（1行の補足説明） */}
       {isDisabled && description && (
-        <p className="text-xs text-zinc-500 dark:text-zinc-400">{description}</p>
+        <p className="text-xs text-stone-500 dark:text-zinc-400">{description}</p>
       )}
     </div>
   );

--- a/app/_components/FacilitiesSection.tsx
+++ b/app/_components/FacilitiesSection.tsx
@@ -228,9 +228,9 @@ function FloorCard({ facility }: FloorCardProps) {
   const { floor, Icon, items } = facility;
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-800/60">
+    <div className="rounded-xl border border-stone-200 bg-white p-5 dark:border-zinc-700 dark:bg-zinc-800/60">
       {/* フロア見出し（h3）：アイコン + フロア名をセットで表示 */}
-      <h3 className="mb-3 flex items-center gap-2 text-base font-semibold text-zinc-900 dark:text-zinc-50">
+      <h3 className="mb-3 flex items-center gap-2 text-base font-semibold text-stone-900 dark:text-zinc-50">
         {/* アイコンは装飾扱い（aria-hidden はアイコン側で設定済み）
          * テキストのフロア名でスクリーンリーダーに意味を伝える
          */}
@@ -245,7 +245,7 @@ function FloorCard({ facility }: FloorCardProps) {
         {items.map((item) => (
           <li
             key={item}
-            className="flex items-start gap-2 text-sm text-zinc-700 dark:text-zinc-300"
+            className="flex items-start gap-2 text-sm text-stone-700 dark:text-zinc-300"
           >
             {/* チェックマーク（装飾）— aria-hidden で読み上げをスキップ */}
             <span aria-hidden="true" className="mt-0.5 shrink-0 text-sky-500">

--- a/app/_components/FeaturesSection.tsx
+++ b/app/_components/FeaturesSection.tsx
@@ -205,15 +205,15 @@ const FEATURES: Feature[] = [
  * FeatureCard — 個別の特徴を1枚のカードとして表示する
  *
  * 構成: アイコン（装飾）→ h3 見出し → 説明文
- * デザイン: bg-slate-50 / rounded-xl / shadow-sm（docs/DESIGN.md §8.5）
+ * デザイン: bg-stone-100 / rounded-xl / shadow-sm（docs/DESIGN.md §8.5、Issue #23 でstone系に統一）
  */
 function FeatureCard({ title, description, Icon }: Feature) {
   return (
-    <article className="flex flex-col gap-4 rounded-xl bg-slate-50 p-6 shadow-sm dark:bg-zinc-800">
+    <article className="flex flex-col gap-4 rounded-xl bg-stone-100 p-6 shadow-sm dark:bg-zinc-800">
       {/* アイコン（装飾用。aria-hidden で読み上げをスキップ） */}
       <div
         aria-hidden="true"
-        className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-slate-700 shadow-sm dark:bg-zinc-700 dark:text-slate-300"
+        className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-stone-700 shadow-sm dark:bg-zinc-700 dark:text-stone-300"
       >
         <Icon />
       </div>
@@ -221,11 +221,11 @@ function FeatureCard({ title, description, Icon }: Feature) {
        * h3: Section（h2）の下に置くことで見出し階層を維持する
        * docs/DESIGN.md §2.2 「階層を飛ばさない」
        */}
-      <h3 className="text-lg font-semibold leading-snug text-slate-900 dark:text-zinc-50">
+      <h3 className="text-lg font-semibold leading-snug text-stone-900 dark:text-zinc-50">
         {title}
       </h3>
       {/* 説明文: text-base / leading-7 で読みやすい行間を確保 */}
-      <p className="text-base leading-7 text-slate-600 dark:text-zinc-400">
+      <p className="text-base leading-7 text-stone-600 dark:text-zinc-400">
         {description}
       </p>
     </article>

--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -12,7 +12,10 @@ function FooterButton({
   return (
     <a
       href={href}
-      className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-900 px-4 text-sm font-medium text-white hover:opacity-90 dark:bg-zinc-50 dark:text-zinc-950"
+      /*
+       * bg-sky-600: 海ブルー（Issue #23 ブランドカラー）を Footer の主要 CTA にも適用
+       */
+      className="inline-flex h-11 items-center justify-center rounded-lg bg-sky-600 px-4 text-sm font-medium text-white hover:opacity-90 dark:bg-sky-500 dark:text-white"
     >
       {children}
     </a>
@@ -23,7 +26,7 @@ function DisabledButton({ label }: { label: string }) {
   return (
     <span
       aria-disabled="true"
-      className="inline-flex h-11 items-center justify-center rounded-lg bg-zinc-200 px-4 text-sm font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+      className="inline-flex h-11 items-center justify-center rounded-lg bg-stone-200 px-4 text-sm font-medium text-stone-600 dark:bg-zinc-800 dark:text-zinc-300"
       title="準備中"
     >
       {label}（準備中）
@@ -36,17 +39,17 @@ export function Footer() {
   const bookingAnchor = anchorHref("booking");
 
   return (
-    <footer className="border-t border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black">
+    <footer className="border-t border-stone-200 bg-white dark:border-zinc-800 dark:bg-black">
       <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
         <div className="flex flex-col gap-8 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
-            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+            <div className="text-sm font-semibold text-stone-900 dark:text-zinc-50">
               {SITE.name}
             </div>
-            <div className="text-sm text-zinc-600 dark:text-zinc-400">{SITE.address}</div>
+            <div className="text-sm text-stone-600 dark:text-zinc-400">{SITE.address}</div>
             <a
               href={SITE.mapUrl}
-              className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
+              className="text-sm font-medium text-sky-700 underline-offset-4 hover:text-sky-800 hover:underline dark:text-sky-400"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -55,7 +58,7 @@ export function Footer() {
           </div>
 
           <div className="space-y-3">
-            <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+            <div className="text-sm font-semibold text-stone-900 dark:text-zinc-50">
               予約
             </div>
             <div className="flex flex-col items-start gap-3">
@@ -70,7 +73,7 @@ export function Footer() {
               )}
               <a
                 href={bookingAnchor}
-                className="text-sm text-zinc-600 underline-offset-4 hover:underline dark:text-zinc-400"
+                className="text-sm text-stone-600 underline-offset-4 hover:underline dark:text-zinc-400"
               >
                 予約・問い合わせセクションへ
               </a>
@@ -78,7 +81,7 @@ export function Footer() {
           </div>
         </div>
 
-        <div className="mt-10 text-xs text-zinc-500 dark:text-zinc-500">
+        <div className="mt-10 text-xs text-stone-500 dark:text-zinc-500">
           © {new Date().getFullYear()} {SITE.name}
         </div>
       </div>

--- a/app/_components/GallerySection.tsx
+++ b/app/_components/GallerySection.tsx
@@ -175,10 +175,10 @@ export function GallerySection() {
         <div className="mx-auto max-w-6xl space-y-10 px-4 sm:px-6">
           {/* ---- セクションヘッダー ---- */}
           <header className="space-y-2">
-            <h2 className="text-2xl font-semibold tracking-tight text-slate-900">
+            <h2 className="text-2xl font-semibold tracking-tight text-stone-900">
               ギャラリー
             </h2>
-            <p className="max-w-3xl text-base leading-7 text-slate-600">
+            <p className="max-w-3xl text-base leading-7 text-stone-600">
               施設内外の写真でご滞在のイメージをご確認ください。写真をタップすると拡大表示します。
             </p>
           </header>
@@ -190,7 +190,7 @@ export function GallerySection() {
                * カテゴリ見出し（h3）
                * h2（セクション）→ h3（カテゴリ）で階層を崩さない（docs/DESIGN.md 2.2 より）
                */}
-              <h3 className="text-xl font-semibold text-slate-900">
+              <h3 className="text-xl font-semibold text-stone-900">
                 {category.title}
               </h3>
 

--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -12,7 +12,7 @@ function HeaderLink({
   return (
     <a
       href={href}
-      className="text-sm font-medium text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50"
+      className="text-sm font-medium text-stone-900 underline-offset-4 hover:underline dark:text-zinc-50"
     >
       {children}
     </a>
@@ -23,11 +23,11 @@ function DisabledItem({ label }: { label: string }) {
   return (
     <span
       aria-disabled="true"
-      className="inline-flex items-center gap-2 text-sm font-medium text-zinc-500 dark:text-zinc-400"
+      className="inline-flex items-center gap-2 text-sm font-medium text-stone-500 dark:text-zinc-400"
       title="準備中"
     >
       <span>{label}</span>
-      <span className="rounded-md border border-zinc-200 px-2 py-0.5 text-xs dark:border-zinc-800">
+      <span className="rounded-md border border-stone-200 px-2 py-0.5 text-xs dark:border-zinc-800">
         準備中
       </span>
     </span>
@@ -38,11 +38,11 @@ export function Header() {
   const items = getHeaderNavItems();
 
   return (
-    <header className="sticky top-0 z-50 border-b border-zinc-200 bg-white/90 backdrop-blur dark:border-zinc-800 dark:bg-black/80">
+    <header className="sticky top-0 z-50 border-b border-stone-200 bg-white/90 backdrop-blur dark:border-zinc-800 dark:bg-black/80">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
         <Link
           href="/"
-          className="text-sm font-semibold tracking-tight text-zinc-900 dark:text-zinc-50"
+          className="text-sm font-semibold tracking-tight text-stone-900 dark:text-zinc-50"
         >
           {SITE.name}
         </Link>

--- a/app/_components/PricingSection.tsx
+++ b/app/_components/PricingSection.tsx
@@ -132,11 +132,11 @@ export function PricingSection() {
     >
       {/* ---- 1. 料金サマリー ---- */}
       {/* ページ上部から「料金を見る → #pricing」で到達した際に最短で要点を把握できるようにする */}
-      <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
-        <p className="text-sm font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+      <div className="rounded-xl border border-stone-200 bg-stone-100 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
+        <p className="text-sm font-semibold uppercase tracking-wider text-stone-500 dark:text-zinc-400">
           料金はじめに
         </p>
-        <ul className="mt-3 space-y-2 text-sm leading-6 text-zinc-700 dark:text-zinc-300">
+        <ul className="mt-3 space-y-2 text-sm leading-6 text-stone-700 dark:text-zinc-300">
           <li>
             <span className="font-medium">最安：オフシーズン 4名まで</span>
             &nbsp;— ¥46,000（清掃費込み）
@@ -153,7 +153,7 @@ export function PricingSection() {
             GW・お盆・シルバーウィーク・年末年始は都度設定
           </li>
         </ul>
-        <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+        <p className="mt-3 text-xs text-stone-500 dark:text-zinc-400">
           ※ 詳細は下記の料金表をご確認ください。
         </p>
       </div>
@@ -163,16 +163,16 @@ export function PricingSection() {
       <div className="overflow-x-auto">
         <table className="w-full min-w-[520px] border-collapse text-sm">
           <thead>
-            <tr className="border-b border-zinc-200 dark:border-zinc-700">
+            <tr className="border-b border-stone-200 dark:border-zinc-700">
               {/* 人数列 */}
-              <th className="py-3 pr-4 text-left font-semibold text-zinc-900 dark:text-zinc-50">
+              <th className="py-3 pr-4 text-left font-semibold text-stone-900 dark:text-zinc-50">
                 人数
               </th>
               {/* シーズン列（4列） */}
               {SEASONS.map((s) => (
                 <th
                   key={s.key}
-                  className="px-3 py-3 text-right font-semibold text-zinc-900 dark:text-zinc-50"
+                  className="px-3 py-3 text-right font-semibold text-stone-900 dark:text-zinc-50"
                 >
                   {s.label}
                 </th>
@@ -183,12 +183,12 @@ export function PricingSection() {
             {PRICING_ROWS.map((row) => (
               <tr
                 key={row.guests}
-                className="border-b border-zinc-100 last:border-0 dark:border-zinc-800"
+                className="border-b border-stone-100 last:border-0 dark:border-zinc-800"
               >
                 {/* 人数 + 使用フロア注記 */}
-                <td className="py-3 pr-4 text-zinc-900 dark:text-zinc-50">
+                <td className="py-3 pr-4 text-stone-900 dark:text-zinc-50">
                   <span className="font-medium">{row.guests}名</span>
-                  <span className="ml-1.5 text-xs text-zinc-500 dark:text-zinc-400">
+                  <span className="ml-1.5 text-xs text-stone-500 dark:text-zinc-400">
                     ({row.note})
                   </span>
                 </td>
@@ -196,7 +196,7 @@ export function PricingSection() {
                 {SEASONS.map((s) => (
                   <td
                     key={s.key}
-                    className="px-3 py-3 text-right tabular-nums text-zinc-700 dark:text-zinc-300"
+                    className="px-3 py-3 text-right tabular-nums text-stone-700 dark:text-zinc-300"
                   >
                     {yen(row.prices[s.key])}
                   </td>
@@ -209,16 +209,16 @@ export function PricingSection() {
 
       {/* シーズン定義の補足 */}
       <div className="space-y-1">
-        <p className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+        <p className="text-xs font-semibold text-stone-500 dark:text-zinc-400">
           シーズン区分の目安
         </p>
         <ul className="space-y-1">
           {SEASONS.map((s) => (
             <li
               key={s.key}
-              className="text-xs leading-5 text-zinc-500 dark:text-zinc-400"
+              className="text-xs leading-5 text-stone-500 dark:text-zinc-400"
             >
-              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+              <span className="font-medium text-stone-700 dark:text-zinc-300">
                 {s.label}：
               </span>
               {s.description}
@@ -230,17 +230,17 @@ export function PricingSection() {
       {/* ---- 3. キャンセルポリシー ---- */}
       <div>
         {/* headingLevel=3: Section の h2 "料金" の下に位置する小見出し */}
-        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        <h3 className="text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50">
           キャンセルポリシー
         </h3>
         <div className="mt-4 overflow-x-auto">
           <table className="w-full min-w-[280px] border-collapse text-sm">
             <thead>
-              <tr className="border-b border-zinc-200 dark:border-zinc-700">
-                <th className="py-2 pr-4 text-left font-semibold text-zinc-900 dark:text-zinc-50">
+              <tr className="border-b border-stone-200 dark:border-zinc-700">
+                <th className="py-2 pr-4 text-left font-semibold text-stone-900 dark:text-zinc-50">
                   キャンセル時期
                 </th>
-                <th className="py-2 text-right font-semibold text-zinc-900 dark:text-zinc-50">
+                <th className="py-2 text-right font-semibold text-stone-900 dark:text-zinc-50">
                   キャンセル料
                 </th>
               </tr>
@@ -249,12 +249,12 @@ export function PricingSection() {
               {CANCELLATION_RULES.map((rule) => (
                 <tr
                   key={rule.timing}
-                  className="border-b border-zinc-100 last:border-0 dark:border-zinc-800"
+                  className="border-b border-stone-100 last:border-0 dark:border-zinc-800"
                 >
-                  <td className="py-2 pr-4 text-zinc-700 dark:text-zinc-300">
+                  <td className="py-2 pr-4 text-stone-700 dark:text-zinc-300">
                     {rule.timing}
                   </td>
-                  <td className="py-2 text-right text-zinc-700 dark:text-zinc-300">
+                  <td className="py-2 text-right text-stone-700 dark:text-zinc-300">
                     {rule.rate}
                   </td>
                 </tr>
@@ -266,17 +266,17 @@ export function PricingSection() {
 
       {/* ---- 4. レンタル料金 ---- */}
       <div>
-        <h3 className="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        <h3 className="text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50">
           レンタル料金
         </h3>
         <div className="mt-4 space-y-5">
           {RENTAL_ITEMS.map((item) => (
             <div key={item.name}>
-              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+              <p className="text-sm font-medium text-stone-900 dark:text-zinc-50">
                 {item.name}
               </p>
               {item.note ? (
-                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                <p className="text-xs text-stone-500 dark:text-zinc-400">
                   {item.note}
                 </p>
               ) : null}
@@ -285,12 +285,12 @@ export function PricingSection() {
                 {item.rows.map((r) => (
                   <div
                     key={r.label}
-                    className="rounded-md border border-zinc-200 px-3 py-1.5 text-sm dark:border-zinc-700"
+                    className="rounded-md border border-stone-200 px-3 py-1.5 text-sm dark:border-zinc-700"
                   >
-                    <span className="text-zinc-500 dark:text-zinc-400">
+                    <span className="text-stone-500 dark:text-zinc-400">
                       {r.label} :{" "}
                     </span>
-                    <span className="font-medium tabular-nums text-zinc-900 dark:text-zinc-50">
+                    <span className="font-medium tabular-nums text-stone-900 dark:text-zinc-50">
                       {yen(r.price)}
                     </span>
                   </div>

--- a/app/_components/Section.tsx
+++ b/app/_components/Section.tsx
@@ -18,18 +18,22 @@ export function Section({
   const HeadingTag = headingLevel === 3 ? "h3" : "h2";
   const headingClassName =
     headingLevel === 3
-      ? "text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50"
-      : "text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50";
+      ? "text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50"
+      : "text-2xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50";
 
   return (
     <section id={id} className="py-12 sm:py-16">
       <div className="mx-auto max-w-6xl space-y-6 px-4 sm:px-6">
         <header className="space-y-2">
-          <HeadingTag className={headingClassName}>
+          {/*
+           * border-l-4 border-sky-500: 海ブルーの左ボーダーラインでブランドカラーを導入（Issue #23）
+           * pl-3: ボーダーと文字の間にスペースを確保
+           */}
+          <HeadingTag className={`${headingClassName} border-l-4 border-sky-500 pl-3`}>
             {title}
           </HeadingTag>
           {lead ? (
-            <p className="max-w-3xl text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            <p className="max-w-3xl text-base leading-7 text-stone-600 dark:text-zinc-400">
               {lead}
             </p>
           ) : null}

--- a/app/_components/SummarySection.tsx
+++ b/app/_components/SummarySection.tsx
@@ -173,16 +173,16 @@ export function SummarySection() {
     <section
       id="summary"
       aria-labelledby="summary-heading"
-      className="border-b border-slate-200 bg-slate-50 py-8 sm:py-10"
+      className="border-b border-stone-200 bg-stone-50 py-8 sm:py-10"
     >
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
         {/*
          * h2: 見出し階層を守るために必須（h1=Hero, h2=各セクション）
-         * text-xl に抑えてコンパクトさを維持する
+         * text-xl に押えてコンパクトさを維持する
          */}
         <h2
           id="summary-heading"
-          className="mb-6 text-xl font-semibold tracking-tight text-slate-900"
+          className="mb-6 text-xl font-semibold tracking-tight text-stone-900"
         >
           基本情報
         </h2>
@@ -198,30 +198,30 @@ export function SummarySection() {
           {SUMMARY_ITEMS.map((item) => (
             <li key={item.label} className="flex flex-col gap-2">
               {/*
-               * アイコン: text-slate-600 で本文より薄め
+               * アイコン: text-stone-600 で本文より薄め
                * サイズは 24×24 px（タッチ対象ではないため小さくてよい）
                */}
-              <span className="text-slate-600" aria-hidden="true">
+              <span className="text-stone-600" aria-hidden="true">
                 {item.icon}
               </span>
 
               {/*
-               * ラベル: 小さめのサポートテキスト（text-sm / text-slate-600）
+               * ラベル: 小さめのサポートテキスト（text-sm / text-stone-600）
                * <dt> ではなく <span> にして視覚的なシンプルさを保つ
                */}
-              <span className="text-sm leading-tight text-slate-600">
+              <span className="text-sm leading-tight text-stone-600">
                 {item.label}
               </span>
 
               {/*
-               * 値: 主役テキスト（text-base / font-semibold / text-slate-900）
+               * 値: 主役テキスト（text-base / font-semibold / text-stone-900）
                * 住所のみ text-sm に縮小して折り返しを制御
                */}
               <span
                 className={
                   item.label === "住所"
-                    ? "text-sm font-semibold leading-snug text-slate-900"
-                    : "text-base font-semibold text-slate-900"
+                    ? "text-sm font-semibold leading-snug text-stone-900"
+                    : "text-base font-semibold text-stone-900"
                 }
               >
                 {item.value}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,34 @@
 @import "tailwindcss";
 
+/**
+ * ブランドカラートークン（Issue #23）
+ * ---------------------------------------------------
+ * beachside コンセプトに合わせた 3 系統のカラーを定義。
+ *
+ *   --color-accent       : 海ブルー（北条海岸） → sky-600 (#0284c7)
+ *   --color-accent-warm  : 砂浜・夕焼け        → amber-400 (#fbbf24)
+ *   --color-base-bg      : 砂浜ベース           → stone-50 (#fafaf9)
+ *   --color-card-bg      : カード背景           → stone-100 (#f5f5f4)
+ *   --color-text-main    : 本文テキスト（濃）   → stone-900 (#1c1917)
+ *   --color-text-sub     : サポートテキスト（薄）→ stone-600 (#57534e)
+ * ---------------------------------------------------
+ * Tailwind クラスと 1:1 対応させることで、
+ * 将来的にトークンを変えるだけで全体に反映できるようにする。
+ */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #fafaf9;  /* stone-50: 砂浜の白さ */
+  --foreground: #1c1917;  /* stone-900: 読みやすい濃いテキスト */
+
+  /* ブランドアクセント */
+  --color-accent: #0284c7;       /* sky-600: 海のブルー */
+  --color-accent-hover: #0369a1; /* sky-700: ホバー時に少し濃く */
+  --color-accent-warm: #fbbf24;  /* amber-400: 砂浜・夕焼け（限定使用） */
+
+  /* ベース */
+  --color-base-bg: #fafaf9;  /* stone-50 */
+  --color-card-bg: #f5f5f4;  /* stone-100 */
+  --color-text-main: #1c1917; /* stone-900 */
+  --color-text-sub: #57534e;  /* stone-600 */
 }
 
 @theme inline {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
-      <body className="flex min-h-full flex-col bg-zinc-50 font-sans text-zinc-900 dark:bg-black dark:text-zinc-50">
+      {/* bg-stone-50: 砂浜のオフホワイト（Issue #23 ブランドカラー導入）
+           text-stone-900: 読みやすい濃いテキスト */}
+      <body className="flex min-h-full flex-col bg-stone-50 font-sans text-stone-900 dark:bg-black dark:text-zinc-50">
         <Header />
         <main className="flex-1">{children}</main>
         <Footer />


### PR DESCRIPTION
## 概要
Closes #23

海辺の貸別荘に相応しいブランドカラーを全コンポーネントに適用する。
グレー（zinc/slate）のみの配色から脱却し「北条海岸の海」「砂浜」を連想させる sky / stone / amber 系に統一した。

## 変更ファイル一覧（12ファイル）
| ファイル | 主な変更内容 |
|---|---|
| `app/globals.css` | CSS カスタムプロパティ追加（`--color-accent` 等 6変数） |
| `app/layout.tsx` | `bg-zinc-50` → `bg-stone-50`、`text-zinc-900` → `text-stone-900` |
| `app/_components/Section.tsx` | 見出し左に `border-l-4 border-sky-500` アクセントライン追加、stone 系統一 |
| `app/_components/CTAButton.tsx` | primary: `bg-zinc-900` → `bg-sky-600`（海ブルー） |
| `app/_components/Header.tsx` | zinc → stone 系に統一 |
| `app/_components/Footer.tsx` | FooterButton: `bg-zinc-900` → `bg-sky-600`、stone 系統一 |
| `app/_components/FeaturesSection.tsx` | `bg-slate-50` → `bg-stone-100` 等 slate → stone 統一 |
| `app/_components/PricingSection.tsx` | zinc → stone 系に統一 |
| `app/_components/AccessSection.tsx` | zinc → stone 系に統一 |
| `app/_components/FacilitiesSection.tsx` | `border-zinc` / `text-zinc` → stone 系に統一 |
| `app/_components/SummarySection.tsx` | slate → stone 系に統一 |
| `app/_components/GallerySection.tsx` | slate → stone 系に統一 |

## 採用カラーパレット
| 用途 | Tailwindクラス | 理由 |
|---|---|---|
| Primary CTA | `bg-sky-600` | 北条海岸の海ブルー |
| アクセントライン | `border-sky-500` | Section 見出し左ライン |
| ベース背景 | `bg-stone-50` | 砂浜のオフホワイト |
| カード背景 | `bg-stone-100` | 清潔感あるサブ背景 |
| 主要テキスト | `text-stone-900` | 読みやすさ優先 |
| サポートテキスト | `text-stone-600` | 弱テキスト |
| リンク色（Footer） | `text-sky-700` | DESIGN.md §8.3 に準拠 |

## 受け入れ条件チェック
- [x] sky アクセントが最低1箇所以上（Section 見出しライン / CTAButton / FooterButton）
- [x] グレーのみの配色から脱却（sky-600 が全 CTA に適用）
- [x] WCAG AA: `stone-900/stone-50` ≈ 17.7:1 ✓、`sky-600/white` ≈ 4.77:1 ✓
- [x] ダークモードで崩れなし（`dark:` クラスをすべて維持）

## ロールバック手順
全変更が Tailwind クラスの差し替えのみのため、本 PR を Revert するだけで完全に戻せる。