### PR TITLE
feat: UI改善③ セクション間の視覚的リズム改善（背景帯の変化）#25

### DIFF
--- a/app/_components/AccessSection.tsx
+++ b/app/_components/AccessSection.tsx
@@ -33,10 +33,12 @@ const TRANSPORT_OPTIONS = ["車", "電車", "バス", "高速ジェット", "フ
 export function AccessSection() {
   return (
     // id="access" を設定して、ヘッダーや他セクションの「アクセス」リンクから到達できるようにする
+    // variant="tinted": 最後に柔らかくまとめるオフホワイト帯（Issue #25）
     <Section
       id={ANCHOR_IDS.access}
       title="アクセス"
-      lead="館山駅から徒歩圏内。海まで徒歩約30秒の好立地です。"
+      lead="館山駅から徒歩圈内。海まで徐歩絀30秒の好立地です。"
+      variant="tinted"
     >
       {/* ---- 住所 + 地図 CTA ---- */}
       <div className="space-y-4 rounded-xl border border-stone-200 bg-stone-100 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">

--- a/app/_components/CTAButton.tsx
+++ b/app/_components/CTAButton.tsx
@@ -4,9 +4,10 @@
  * 役割（variant）に応じてスタイルを変え、URL 未設定時は「準備中」で無効化する。
  *
  * variant の使い分け（docs/DESIGN.md 8.4 より）:
- *   - "primary"   : 最も押してほしい行動（塗り）   例: ご宿泊予約
- *   - "secondary" : 次点の補助行動（枠）           例: LINE で問い合わせ
- *   - "tertiary"  : 補助的なリンク（テキスト下線） 例: Googleマップで開く
+ *   - "primary"        : 最も押してほしい行動（塗り）        例: ご宿泊予約
+ *   - "secondary"      : 次点の補助行動（枠）                例: LINE で問い合わせ
+ *   - "tertiary"       : 補助的なリンク（テキスト下線）      例: Googleマップで開く
+ *   - "outlined-white" : accent 帯（sky-700）上での白枠ボタン 例: 予約CTA（Issue #25）
  *
  * 無効化（URL 未設定時）:
  *   - ボタン文言を「準備中」に切り替える
@@ -14,7 +15,11 @@
  *   - description が渡された場合は 1 行の補足説明を直下に表示する
  */
 
-type Variant = "primary" | "secondary" | "tertiary";
+/**
+ * outlined-white: accent 帯（bg-sky-600 / bg-sky-700）の上で使う白枠ボタン（Issue #25）
+ * 背景が濃い青帯の時に primary（bg-sky-600）は溶け込んでしまうため、反転色で際立たせる
+ */
+type Variant = "primary" | "secondary" | "tertiary" | "outlined-white";
 
 type CTAButtonProps = {
   /** ボタンの重要度（デフォルト: "primary"） */
@@ -53,6 +58,12 @@ const VARIANT_STYLES: Record<Variant, string> = {
     "border border-stone-900 text-stone-900 hover:opacity-80 dark:border-zinc-50 dark:text-zinc-50",
   tertiary:
     "text-stone-900 underline underline-offset-4 hover:opacity-70 dark:text-zinc-50",
+  /*
+   * outlined-white: accent 帯（bg-sky-600 / bg-sky-700）上で使用（Issue #25）
+   * 白い枠線 + 白文字で、濃い青背景に対してコントラストを確保する
+   */
+  "outlined-white":
+    "border border-white text-white hover:bg-white/10",
 };
 
 /**

--- a/app/_components/FeaturesSection.tsx
+++ b/app/_components/FeaturesSection.tsx
@@ -244,10 +244,12 @@ function FeatureCard({ title, description, Icon }: Feature) {
  */
 export function FeaturesSection() {
   return (
+    // variant="tinted": カードと背景のコントラストを確保（Issue #25）
     <Section
       id={ANCHOR_IDS.features}
       title="選ばれる理由"
       lead="TATEYAMA BASE 北条が選ばれる5つのポイントをご紹介します。"
+      variant="tinted"
     >
       {/*
        * カードグリッド

--- a/app/_components/GallerySection.tsx
+++ b/app/_components/GallerySection.tsx
@@ -171,7 +171,11 @@ export function GallerySection() {
   return (
     <>
       {/* ---- セクション全体 ---- */}
-      <section id="gallery" className="py-12 sm:py-16">
+      {/*
+       * bg-stone-50: 写真を明るく見せるオフホワイト帯（Issue #25）
+       * 白背景より写真の翌が身だ、スクロール時の湊切りになる
+       */}
+      <section id="gallery" className="bg-stone-50 py-12 sm:py-16">
         <div className="mx-auto max-w-6xl space-y-10 px-4 sm:px-6">
           {/* ---- セクションヘッダー ---- */}
           <header className="space-y-2">

--- a/app/_components/Section.tsx
+++ b/app/_components/Section.tsx
@@ -1,39 +1,91 @@
 type HeadingLevel = 2 | 3;
 
+/**
+ * variant の種類（Issue #25 視覚リズム改善）:
+ *   - "default"      : 白背景（デフォルト）
+ *   - "tinted"       : bg-stone-50（柔らかいオフホワイト帯）
+ *   - "accent"       : bg-sky-600 テキスト白（目立たせたい重要セクション用）
+ *   - "accent-dark"  : bg-sky-700 テキスト白（予約CTAなど最下部の特別帯用）
+ */
+type Variant = "default" | "tinted" | "accent" | "accent-dark";
+
 type Props = {
   id?: string;
   title: string;
   lead?: string;
   headingLevel?: HeadingLevel;
+  /** セクション背景の種類。未指定時は "default"（白背景）を維持する。後方互換あり。 */
+  variant?: Variant;
   children?: React.ReactNode;
 };
+
+// ---- variant 別スタイル定義 ----
+
+/** セクション全体の背景クラス */
+const SECTION_BG: Record<Variant, string> = {
+  default: "bg-white",
+  tinted: "bg-stone-50",
+  // accent: 海ブルー帯。予約CTAや施設スペックを際立たせる
+  accent: "bg-sky-600",  // accent-dark: 浓いブルー帯。ページ最下部の予約CTAで隣の accent 帯と差別化
+  "accent-dark": "bg-sky-700",};
+
+/** 見出し（h2/h3）のテキスト色クラス */
+const HEADING_COLOR: Record<Variant, string> = {
+  default: "text-stone-900 dark:text-zinc-50",
+  tinted: "text-stone-900 dark:text-zinc-50",
+  // accent帯は白文字に反転
+  accent: "text-white",
+  "accent-dark": "text-white",
+};
+
+/** 左ボーダーアクセントラインの色クラス（Issue #23 ブランドカラー準拠） */
+const BORDER_COLOR: Record<Variant, string> = {
+  default: "border-sky-500",
+  tinted: "border-sky-500",
+  // accent帯では白いボーダーで視認性を確保
+  accent: "border-white/60",
+  "accent-dark": "border-white/60",
+};
+
+/** リード文のテキスト色クラス */
+const LEAD_COLOR: Record<Variant, string> = {
+  default: "text-stone-600 dark:text-zinc-400",
+  tinted: "text-stone-600 dark:text-zinc-400",
+  // accent帯では sky-100 で少し抑えた白（眩しくしない）
+  accent: "text-sky-100",  "accent-dark": "text-sky-100",};
 
 export function Section({
   id,
   title,
   lead,
   headingLevel = 2,
+  variant = "default",
   children,
 }: Props) {
   const HeadingTag = headingLevel === 3 ? "h3" : "h2";
+  // headingLevel と variant を組み合わせて見出しのクラスを組み立てる
   const headingClassName =
     headingLevel === 3
-      ? "text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50"
-      : "text-2xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50";
+      ? `text-xl font-semibold tracking-tight ${HEADING_COLOR[variant]}`
+      : `text-2xl font-semibold tracking-tight ${HEADING_COLOR[variant]}`;
 
   return (
-    <section id={id} className="py-12 sm:py-16">
+    // variant に応じた背景色を適用。py は全 variant 共通
+    <section id={id} className={`${SECTION_BG[variant]} py-12 sm:py-16`}>
       <div className="mx-auto max-w-6xl space-y-6 px-4 sm:px-6">
         <header className="space-y-2">
           {/*
-           * border-l-4 border-sky-500: 海ブルーの左ボーダーラインでブランドカラーを導入（Issue #23）
+           * border-l-4: 見出し左のアクセントライン（Issue #23 ブランドカラー）
+           * variant="accent" 時は border-white/60 に切り替えて帯との調和を保つ
            * pl-3: ボーダーと文字の間にスペースを確保
            */}
-          <HeadingTag className={`${headingClassName} border-l-4 border-sky-500 pl-3`}>
+          <HeadingTag
+            className={`${headingClassName} border-l-4 ${BORDER_COLOR[variant]} pl-3`}
+          >
             {title}
           </HeadingTag>
           {lead ? (
-            <p className="max-w-3xl text-base leading-7 text-stone-600 dark:text-zinc-400">
+            <p className={`max-w-3xl text-base leading-7 ${LEAD_COLOR[variant]}`}>
               {lead}
             </p>
           ) : null}

--- a/app/_components/SummarySection.tsx
+++ b/app/_components/SummarySection.tsx
@@ -173,16 +173,21 @@ export function SummarySection() {
     <section
       id="summary"
       aria-labelledby="summary-heading"
-      className="border-b border-stone-200 bg-stone-50 py-8 sm:py-10"
+      /**
+       * bg-sky-600: Hero 直後に海ブルーの accent 帯を置き、施設スペックを目立たせる（Issue #25）
+       * py-10 sm:py-14: 余白を少し広げて帯の存在感を強調
+       */
+      className="bg-sky-600 py-10 sm:py-14"
     >
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
         {/*
          * h2: 見出し階層を守るために必須（h1=Hero, h2=各セクション）
          * text-xl に押えてコンパクトさを維持する
+         * text-white: accent帯では白文字に反転（Issue #25）
          */}
         <h2
           id="summary-heading"
-          className="mb-6 text-xl font-semibold tracking-tight text-stone-900"
+          className="mb-6 text-xl font-semibold tracking-tight text-white"
         >
           基本情報
         </h2>
@@ -198,30 +203,30 @@ export function SummarySection() {
           {SUMMARY_ITEMS.map((item) => (
             <li key={item.label} className="flex flex-col gap-2">
               {/*
-               * アイコン: text-stone-600 で本文より薄め
+               * アイコン: accent帯では text-sky-200 で少し抑えた白（眩しくしない）（Issue #25）
                * サイズは 24×24 px（タッチ対象ではないため小さくてよい）
                */}
-              <span className="text-stone-600" aria-hidden="true">
+              <span className="text-sky-200" aria-hidden="true">
                 {item.icon}
               </span>
 
               {/*
-               * ラベル: 小さめのサポートテキスト（text-sm / text-stone-600）
+               * ラベル: accent帯では text-sky-100 でサポートテキストを柔らかく表示（Issue #25）
                * <dt> ではなく <span> にして視覚的なシンプルさを保つ
                */}
-              <span className="text-sm leading-tight text-stone-600">
+              <span className="text-sm leading-tight text-sky-100">
                 {item.label}
               </span>
 
               {/*
-               * 値: 主役テキスト（text-base / font-semibold / text-stone-900）
+               * 値: 主役テキスト。accent帯では text-white に反転（Issue #25）
                * 住所のみ text-sm に縮小して折り返しを制御
                */}
               <span
                 className={
                   item.label === "住所"
-                    ? "text-sm font-semibold leading-snug text-stone-900"
-                    : "text-base font-semibold text-stone-900"
+                    ? "text-sm font-semibold leading-snug text-white"
+                    : "text-base font-semibold text-white"
                 }
               >
                 {item.value}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,18 +47,24 @@ export default function Home() {
       <AccessSection />
 
       {/* Booking: 予約・問い合わせ CTA（ページ下部で再掲） */}
+      {/*
+       * variant="accent-dark": bg-sky-700 の濃いブルー帯で予約 CTA を際立たせる（Issue #25）
+       * 隣の AccessSection（tinted）とコントラストをつけ、「状態が変わった」ことを視覚的に伝える
+       */}
       <Section
         id={ANCHOR_IDS.booking}
         title="予約・問い合わせ"
         lead="ご予約は外部サービス（STORES）から承ります。ご不明な点はお気軽に LINE でお問い合わせください。"
+        variant="accent-dark"
       >
         <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
           {/*
            * 予約 CTA（最重要）
+           * variant="outlined-white": accent-dark 帯の上で白枠で際立たせる（Issue #25）
            * NEXT_PUBLIC_BOOKING_URL 未設定時は「準備中」で自動的に無効化される
            */}
           <CTAButton
-            variant="primary"
+            variant="outlined-white"
             href={bookingUrl}
             external
             description={
@@ -70,10 +76,11 @@ export default function Home() {
 
           {/*
            * LINE 問い合わせ CTA（補助）
+           * variant="outlined-white": accent-dark 帯の上で白枠、予約ボタンとスタイルを揃える（Issue #25）
            * NEXT_PUBLIC_LINE_URL 未設定時は「準備中」で自動的に無効化される
            */}
           <CTAButton
-            variant="secondary"
+            variant="outlined-white"
             href={SITE.lineUrl}
             external
             description={


### PR DESCRIPTION
## 概要

全セクションが同一背景・同一スタイルで並んでいた問題を解消。
`Section` コンポーネントに `variant` prop を追加し、セクションごとに背景帯を切り替えることで視覚的なリズムを作りました。

Closes #25

---

## 変更ファイル一覧と方針

| ファイル | 変更内容 |
|---|---|
| `Section.tsx` | `variant` prop 追加（`default` / `tinted` / `accent` / `accent-dark`） |
| `SummarySection.tsx` | `bg-sky-600` 海ブルー帯・テキスト白系に統一 |
| `GallerySection.tsx` | `bg-stone-50` を付与 |
| `FeaturesSection.tsx` | `variant="tinted"` 適用 |
| `AccessSection.tsx` | `variant="tinted"` 適用 |
| `page.tsx` | booking セクション `variant="accent-dark"`（`bg-sky-700`）に変更 |
| `CTAButton.tsx` | `outlined-white` variant 追加（accent 帯上の白枠ボタン） |

## セクションの背景色マッピング

| セクション | 背景 |
|---|---|
| SummarySection | `bg-sky-600`（accent） |
| GallerySection | `bg-stone-50` |
| PricingSection | `bg-white`（変更なし） |
| FeaturesSection | `bg-stone-50`（tinted） |
| FacilitiesSection | `bg-white`（変更なし） |
| AccessSection | `bg-stone-50`（tinted） |
| BookingSection | `bg-sky-700`（accent-dark） |

## 受け入れ条件チェック

- [x] スクロールするとセクションごとに背景色が変化している
- [x] SummarySection が sky の色帯で目立っている
- [x] 予約セクションが他セクションと明確に区別できる
- [x] Section コンポーネントの `variant` 未指定時に既存の白背景が維持される

## ロールバック方法

`variant` prop はデフォルト値 `"default"` で後方互換を維持しているため、
各コンポーネントから `variant` prop を削除するだけで元の白背景に戻ります。

## テスト

- `npx tsc --noEmit` → エラーなし ✅
- `npm run build` → ビルド成功 ✅
- 手動確認: dev サーバーでスクロールし、各セクションの背景色切り替えを目視確認