### PR TITLE
feat: UI改善④ タイポグラフィの強弱追加（数値の大見出し化）#26

### DIFF
--- a/app/_components/FeaturesSection.tsx
+++ b/app/_components/FeaturesSection.tsx
@@ -211,9 +211,11 @@ function FeatureCard({ title, description, Icon }: Feature) {
   return (
     <article className="flex flex-col gap-4 rounded-xl bg-stone-100 p-6 shadow-sm dark:bg-zinc-800">
       {/* アイコン（装飾用。aria-hidden で読み上げをスキップ） */}
+      {/* Issue #26: bg-sky-50 / text-sky-600 でブランドカラーのアクセントを付与 */}
+      {/* dark モードは sky-900/40 背景 + sky-400 アイコンで視認性を維持 */}
       <div
         aria-hidden="true"
-        className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-stone-700 shadow-sm dark:bg-zinc-700 dark:text-stone-300"
+        className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-50 text-sky-600 dark:bg-sky-900/40 dark:text-sky-400"
       >
         <Icon />
       </div>

--- a/app/_components/PricingSection.tsx
+++ b/app/_components/PricingSection.tsx
@@ -136,10 +136,22 @@ export function PricingSection() {
         <p className="text-sm font-semibold uppercase tracking-wider text-stone-500 dark:text-zinc-400">
           料金はじめに
         </p>
+
+        {/*
+         * Issue #26: アンカー価格（最安値）を大きく打ち出す
+         * text-4xl font-bold tabular-nums: 数値を大きく・桁揃えで表示
+         * text-sky-700: ブランドカラーで視線を誘導する
+         */}
+        <div className="mt-3 flex flex-wrap items-baseline gap-2">
+          <span className="text-4xl font-bold tabular-nums text-sky-700 dark:text-sky-400">
+            ¥46,000〜
+          </span>
+          <span className="text-sm text-stone-500 dark:text-zinc-400">清掃費込み</span>
+        </div>
+
         <ul className="mt-3 space-y-2 text-sm leading-6 text-stone-700 dark:text-zinc-300">
           <li>
             <span className="font-medium">最安：オフシーズン 4名まで</span>
-            &nbsp;— ¥46,000（清掃費込み）
           </li>
           <li>
             <span className="font-medium">宿泊人数：</span>4〜8名

--- a/app/_components/SummarySection.tsx
+++ b/app/_components/SummarySection.tsx
@@ -139,21 +139,25 @@ type SummaryItem = {
 const SUMMARY_ITEMS: SummaryItem[] = [
   {
     label: "宿泊人数",
+    // 「4〜8名」をそのままメイン値として大きく出す
     value: "4〜8名",
     icon: <UsersIcon />,
   },
   {
-    label: "海まで",
-    value: "徒歩約30秒",
+    // ラベルに「海まで徒歩」、数値（秒）だけを大きく打ち出す
+    label: "海まで徒歩",
+    value: "約30秒",
     icon: <WavesIcon />,
   },
   {
-    label: "館山駅から",
-    value: "徒歩約9分",
+    // ラベルに「館山駅から徒歩」、数値（分）だけを大きく打ち出す
+    label: "館山駅から徒歩",
+    value: "約9分",
     icon: <WalkIcon />,
   },
   {
     label: "住所",
+    // 住所は数値ではないため、value は小さめのままにする
     value: "〒294-0045 千葉県館山市北条2278-3",
     icon: <MapPinIcon />,
   },
@@ -219,14 +223,16 @@ export function SummarySection() {
               </span>
 
               {/*
-               * 値: 主役テキスト。accent帯では text-white に反転（Issue #25）
-               * 住所のみ text-sm に縮小して折り返しを制御
+               * 値（メインの数値・キーワード）: Issue #26 タイポグラフィ強弱
+               * - 住所: 数値ではないため text-sm font-semibold に留める
+               * - それ以外: text-3xl font-bold tabular-nums（桁揃え）で大きく打ち出す
+               * tabular-nums: 数字幅を均等にそろえ、数値の視認性を高める
                */}
               <span
                 className={
                   item.label === "住所"
                     ? "text-sm font-semibold leading-snug text-white"
-                    : "text-base font-semibold text-white"
+                    : "text-3xl font-bold tabular-nums text-white"
                 }
               >
                 {item.value}


### PR DESCRIPTION
## 概要

Issue #26 の実装。「徒歩30秒」「¥46,000〜」「4〜8名」などの重要数値を、旅行サイト標準の「数字を超大きく打ち出す」スタイルに変更。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `SummarySection.tsx` | 数値を `text-3xl font-bold tabular-nums` に拡大 |
| `FeaturesSection.tsx` | アイコン背景を `bg-sky-50 text-sky-600` に変更 |
| `PricingSection.tsx` | アンカー価格を `text-4xl font-bold text-sky-700` で強調追加 |
| `Section.tsx` | 変更なし（`border-l-4 border-sky-500` は既実装済み） |

## 実装詳細

### SummarySection
- `SUMMARY_ITEMS` のラベルを「海まで徒歩」「館山駅から徒歩」に整理し、数値部分（"約30秒" / "約9分"）を分離
- 数値の表示クラスを `text-base font-semibold` → `text-3xl font-bold tabular-nums` に変更
- 住所は数値ではないため `text-sm font-semibold` のまま

### FeaturesSection
- アイコンコンテナを `bg-white text-stone-700` → `bg-sky-50 text-sky-600` に変更（ブランドカラー統一）
- ダークモード対応: `dark:bg-sky-900/40 dark:text-sky-400`

### PricingSection
- 料金サマリーに `¥46,000〜（清掃費込み）` を `text-4xl font-bold tabular-nums text-sky-700` で新たに強調表示
- 既存の箇条書き「最安：オフシーズン 4名まで」との重複を整理

## 受け入れ条件チェック

- [x] SummarySection の数値（秒・分・名）が一目で大きく読める
- [x] 各セクションの見出しにアクセントラインが入っている（Section.tsx 既実装）
- [x] PricingSection に最安値のアンカー価格が大きく表示されている
- [x] スマホで数値が折り返さずに読める（短文 + grid-cols-2 で幅確保）

## ロールバック手順

Tailwind クラスの差分のみ。`git revert 7392d20` または当コミットの差分を手動で戻すだけで完結。

Closes #26