### PR TITLE
feat(ui): CTAボタンをブランドカラー(sky-600)に統一 #27

### DIFF
--- a/app/_components/CTAButton.tsx
+++ b/app/_components/CTAButton.tsx
@@ -4,10 +4,11 @@
  * 役割（variant）に応じてスタイルを変え、URL 未設定時は「準備中」で無効化する。
  *
  * variant の使い分け（docs/DESIGN.md 8.4 より）:
- *   - "primary"        : 最も押してほしい行動（塗り）        例: ご宿泊予約
- *   - "secondary"      : 次点の補助行動（枠）                例: LINE で問い合わせ
- *   - "tertiary"       : 補助的なリンク（テキスト下線）      例: Googleマップで開く
- *   - "outlined-white" : accent 帯（sky-700）上での白枠ボタン 例: 予約CTA（Issue #25）
+ *   - "primary"         : 最も押してほしい行動（sky-600 塗り）  例: ご宿泊予約
+ *   - "secondary"       : 次点の補助行動（sky-600 枠）          例: LINE で問い合わせ
+ *   - "tertiary"        : 補助的なリンク（テキスト下線）         例: Googleマップで開く
+ *   - "outlined-white"  : accent 帯（sky 背景）上での白枠ボタン 例: 予約CTA（Issue #25）
+ *   - "primary-inverse" : accent 帯（sky 背景）上での白塗りボタン（Issue #27）
  *
  * 無効化（URL 未設定時）:
  *   - ボタン文言を「準備中」に切り替える
@@ -16,10 +17,11 @@
  */
 
 /**
- * outlined-white: accent 帯（bg-sky-600 / bg-sky-700）の上で使う白枠ボタン（Issue #25）
- * 背景が濃い青帯の時に primary（bg-sky-600）は溶け込んでしまうため、反転色で際立たせる
+ * outlined-white  : accent 帯（bg-sky-600 / bg-sky-700）上の白枠ボタン（Issue #25）
+ * primary-inverse : accent 帯上の白塗り・sky 文字ボタン（Issue #27）
+ * → どちらも「sky 背景に対して視認性を確保するための反転系」
  */
-type Variant = "primary" | "secondary" | "tertiary" | "outlined-white";
+type Variant = "primary" | "secondary" | "tertiary" | "outlined-white" | "primary-inverse";
 
 type CTAButtonProps = {
   /** ボタンの重要度（デフォルト: "primary"） */
@@ -43,36 +45,56 @@ type CTAButtonProps = {
 // ---- スタイル定義 ----
 
 /** すべての variant に共通するベースクラス */
+// shadow-sm: DESIGN.md §8.4 準拠（ボタンに軽い影を付けて立体感を出す）
+// transition-colors: opacity だけでなく背景色・枠線色も滑らかに変化させる
 const BASE =
-  "inline-flex h-11 items-center justify-center rounded-lg px-5 text-sm font-medium transition-opacity";
+  "inline-flex h-11 items-center justify-center rounded-lg px-5 text-sm font-medium shadow-sm transition-colors";
 
 /** 有効時の variant 別スタイル */
 const VARIANT_STYLES: Record<Variant, string> = {
+  /*
+   * primary: bg-sky-600（海ブルー）= ブランドカラー（DESIGN.md §8.3）
+   * ホバーで bg-sky-700 に変化（opacity 変化より「色変化」の方が意図が明確）
+   * active: bg-sky-800（押した瞬間さらに濃く）
+   * focus-visible: キーボード操作時のフォーカスリング（DESIGN.md §4.2・§8.4 必須要件）
+   */
   primary:
-    /*
-     * bg-sky-600: 海ブルー（Issue #23 ブランドカラー）
-     * 北条海岸の海をイメージしたプライマリ CTA
-     */
-    "bg-sky-600 text-white hover:opacity-90 dark:bg-sky-500 dark:text-white",
+    "bg-sky-600 text-white hover:bg-sky-700 active:bg-sky-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2",
+  /*
+   * secondary: sky-600 の枠線 + sky-700 テキスト
+   * border-2 にして primary との視覚的な重みを揃える
+   * hover:bg-sky-50 で「気づきやすい変化」を提供
+   */
   secondary:
-    "border border-stone-900 text-stone-900 hover:opacity-80 dark:border-zinc-50 dark:text-zinc-50",
+    "border-2 border-sky-600 text-sky-700 hover:bg-sky-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2",
+  /*
+   * tertiary: テキストリンク風。DESIGN.md §8.3 のリンク色（sky-700）に統一
+   * hover:text-sky-800 でやや濃くして変化を伝える
+   */
   tertiary:
-    "text-stone-900 underline underline-offset-4 hover:opacity-70 dark:text-zinc-50",
+    "text-sky-700 underline underline-offset-4 hover:text-sky-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2",
   /*
    * outlined-white: accent 帯（bg-sky-600 / bg-sky-700）上で使用（Issue #25）
    * 白い枠線 + 白文字で、濃い青背景に対してコントラストを確保する
    */
   "outlined-white":
-    "border border-white text-white hover:bg-white/10",
+    "border-2 border-white text-white hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-sky-700",
+  /*
+   * primary-inverse: accent 帯（sky 背景）上での白塗りボタン（Issue #27）
+   * 白い背景 + sky-700 テキストで、濃い青帯に対して最大コントラストを確保
+   * outlined-white より視覚的重みが大きく「最もクリックしてほしい」場面で使う
+   */
+  "primary-inverse":
+    "bg-white text-sky-700 hover:bg-sky-50 active:bg-sky-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-sky-700",
 };
 
 /**
  * 無効状態のクラスを生成する。
- * DESIGN.md の「薄くする（opacity）＋カーソル禁止」に準拠し、
- * variant の色はそのままに opacity-40 + cursor-not-allowed を重ねる。
+ * DESIGN.md §8.4「薄くする（opacity）＋カーソル禁止」に準拠。
+ * opacity-50 は §8.4 の規定値（旧 opacity-40 より視認しやすく、かつ「押せない」感を伝える）
  */
 function disabledClass(variant: Variant): string {
-  return `${VARIANT_STYLES[variant]} opacity-40 cursor-not-allowed`;
+  return `${VARIANT_STYLES[variant]} opacity-50 cursor-not-allowed`;
 }
 
 export function CTAButton({


### PR DESCRIPTION
## 概要

Issue #27 の実装。CTA ボタンのカラーを黒系（zinc-900）から海ブルー（sky-600）に統一し、
「海・アクティビティ」ブランドコンセプトとの一貫性を確保する。

## 変更ファイル

- `app/_components/CTAButton.tsx`（1 ファイルのみ）

## 変更内容

### VARIANT_STYLES の更新

| variant | 変更前 | 変更後 |
|---|---|---|
| `primary` 背景 | `bg-zinc-900`→`bg-sky-600 hover:opacity-90` | `bg-sky-600 hover:bg-sky-700 active:bg-sky-800` |
| `secondary` 枠 | `border border-stone-900 text-stone-900` | `border-2 border-sky-600 text-sky-700 hover:bg-sky-50` |
| `tertiary` 色 | `text-stone-900` | `text-sky-700 hover:text-sky-800` |
| `outlined-white` 枠 | `border border-white` | `border-2 border-white` + focus-visible 追加 |
| `primary-inverse` | なし | 新規追加（accent 帯上の白塗り CTA 用） |

### その他の改善

- `BASE` クラスに `shadow-sm` を追加（DESIGN.md §8.4）
- `transition-opacity` → `transition-colors` に変更（色変化アニメを正確に処理）
- 全 variant に `focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2` を追加（DESIGN.md §4.2・§8.4）
- `disabledClass` の `opacity-40` → `opacity-50` に変更（DESIGN.md §8.4）

## 受け入れ条件チェック

- [x] Primary ボタンが `sky-600` 系の色になっている
- [x] ホバーで色が変化する（`hover:bg-sky-700`）
- [x] `focus-visible` でフォーカスリングが見える（Tab キーで確認可）
- [x] 無効状態が `opacity-50 cursor-not-allowed` になっている
- [x] accent 帯内の CTA が背景色と区別できる（`outlined-white` / `primary-inverse`）

## 手動確認手順

1. ローカルで `npm run dev` を起動
2. http://localhost:3000 を開く
3. 各 CTA ボタンを確認:
   - [ ] Hero の「ご宿泊予約」が sky-600（海ブルー）で表示される
   - [ ] キーボード Tab でフォーカスを移動 → sky-500 のフォーカスリングが表示される
   - [ ] ホバー時に sky-700 に色変化する（opacity 変化ではなく色変化）
   - [ ] アクセスセクションの地図リンク（tertiary）が sky-700 テキストになっている
   - [ ] 準備中ボタンが薄く（opacity-50）+ カーソル禁止（cursor-not-allowed）になっている

## ロールバック手順

`VARIANT_STYLES` を元の値（`bg-zinc-900` 系）に戻すだけで全ページが元に戻る。

## 依存関係

Issue #1（ブランドカラー導入）の `stone-50` 背景と合わせて使われることを想定済み。