### PR TITLE
feat: FeaturesSection を写真付きビジュアルカードに刷新 (#35)

### DIFF
--- a/app/_components/FeaturesSection.tsx
+++ b/app/_components/FeaturesSection.tsx
@@ -1,26 +1,38 @@
 /**
  * FeaturesSection — 特徴セクション（選ばれる理由）
  *
- * 目的: 施設の「選ばれる理由」を言語化し、予約への動機づけを強化する。
+ * 目的: 施設の「選ばれる理由」を写真付きビジュアルカードで訴求し、予約への動機づけを強化する。
  *
  * 掲載情報（docs/FACTS.md の確定情報のみ使用）:
  *   - 1棟貸し（4〜8名）
- *   - 屋上テラス・1階ウッドデッキ
+ *   - 屋上テラス
+ *   - 1階ウッドデッキ
  *   - 室内アクティビティ（卓球・麻雀）
  *   - レンタル用品（SUP等）
- *   - 立地（海まで徒歩約30秒・館山駅から徒歩約9分）
  *
+ * Issue #35: アイコン → 写真へ刷新。PC で左右交互の2カラム、スマホで縦積みレイアウト。
  * デザイン準拠: docs/DESIGN.md（余白・フォント・カラールール）
  * セマンティック: <section> > <h2> > カード内 <h3> で見出し階層を維持
  * IA.md: セクション順 4番目（料金の後・設備の前）
  */
 
+import Image, { type StaticImageData } from "next/image";
+
+// ────────────────────────────────────────────────────────
+// 写真のインポート（imgs/ 以下。next/image が最適化する）
+// StaticImport を使うと width / height が自動で取得され、CLS（レイアウトズレ）を防げる
+// ────────────────────────────────────────────────────────
+import livingImg from "../../imgs/living.jpg";
+import rooftopImg from "../../imgs/rooftop-terrace.jpg";
+import woodTerraceImg from "../../imgs/wood-terrace.jpg";
+import tableTennisImg from "../../imgs/table-tennis.jpg";
+import sapImg from "../../imgs/sap.jpg";
+
 import { ANCHOR_IDS } from "../_lib/anchors";
 import { Section } from "./Section";
 
 // ────────────────────────────────────────────────────────
-// 特徴データ（docs/FACTS.md の確定情報のみ）
-// 根拠のない断定（「最高」「No.1」等）は使わない
+// 特徴データ型（Issue #35: Icon を削除し image / alt を追加）
 // ────────────────────────────────────────────────────────
 
 type Feature = {
@@ -28,135 +40,21 @@ type Feature = {
   title: string;
   /** 説明文（確定情報を使用・断定表現は避ける） */
   description: string;
-  /** アイコンコンポーネント */
-  Icon: () => React.JSX.Element;
+  /**
+   * 代表写真（next/image の StaticImageData）
+   * next/image に渡すと自動で WebP 変換・リサイズが行われる
+   */
+  image: StaticImageData;
+  /**
+   * 画像の alt テキスト（アクセシビリティ必須）
+   * docs/DESIGN.md §3 「画像の alt は内容を具体的に書く」
+   */
+  alt: string;
 };
 
 // ────────────────────────────────────────────────────────
-// アイコン（インライン SVG）
-// aria-hidden="true" で装飾扱いとし、テキストで意味を伝える
-// ────────────────────────────────────────────────────────
-
-/** 家・建物アイコン（1棟貸し） */
-function HouseIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      {/* 屋根 */}
-      <path d="M3 9.5 12 3l9 6.5" />
-      {/* 建物の外壁 */}
-      <path d="M19 10v11H5V10" />
-      {/* ドア */}
-      <rect x="9" y="14" width="6" height="7" rx="0.5" />
-    </svg>
-  );
-}
-
-/** 太陽アイコン（屋上テラス・ウッドデッキ） */
-function SunIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      {/* 太陽の円 */}
-      <circle cx="12" cy="12" r="4" />
-      {/* 放射線 8本 */}
-      <path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
-    </svg>
-  );
-}
-
-/** ゲーム・卓球アイコン（室内アクティビティ） */
-function TableTennisIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      {/* ラケット（円形ヘッド） */}
-      <circle cx="9" cy="9" r="5" />
-      {/* グリップ */}
-      <line x1="13" y1="13" x2="20" y2="20" />
-      {/* ボール */}
-      <circle cx="19" cy="5" r="2" />
-    </svg>
-  );
-}
-
-/** 波・サップアイコン（レンタル用品） */
-function SurfIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      {/* 波 2段 */}
-      <path d="M2 9c.6.5 1.2 1 2.5 1C7 10 7 8 9.5 8c2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
-      <path d="M2 15c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
-    </svg>
-  );
-}
-
-/** マップピンアイコン（立地） */
-function MapPinIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      {/* ピン外形 */}
-      <path d="M20 10c0 6-8 13-8 13S4 16 4 10a8 8 0 1 1 16 0z" />
-      {/* 中心の丸 */}
-      <circle cx="12" cy="10" r="3" />
-    </svg>
-  );
-}
-
-// ────────────────────────────────────────────────────────
 // 特徴リスト（docs/FACTS.md の確定情報のみ）
+// 注: 立地情報（海まで徒歩約30秒等）は AccessSection でカバーするため除外
 // ────────────────────────────────────────────────────────
 
 /**
@@ -169,67 +67,123 @@ const FEATURES: Feature[] = [
     title: "1棟貸し（4〜8名）",
     description:
       "グループや家族で全館を独占できる貸別荘です。人数に合わせて1階のみ、または1・2階の両フロアを使えます。",
-    Icon: HouseIcon,
+    image: livingImg,
+    alt: "リビングの様子。ソファや広い室内が見える",
   },
   {
-    title: "屋上テラス・1階ウッドデッキ",
+    title: "屋上テラス",
     description:
-      "屋外スペースを2か所確保。海風を感じながらくつろいだり、空を眺めたりと、室内とは違う時間を過ごせます。",
-    Icon: SunIcon,
+      "屋上に専用テラスを確保。海風を感じながら空を見上げる時間は、室内では得られない開放感があります。",
+    image: rooftopImg,
+    alt: "屋上テラスの様子。青空と海が見渡せる",
+  },
+  {
+    title: "1階ウッドデッキ",
+    description:
+      "1階の屋外にウッドデッキを設置。アウトドアシャワーと合わせて、砂浜からそのままくつろげる動線です。",
+    image: woodTerraceImg,
+    alt: "1階ウッドデッキの様子",
   },
   {
     title: "室内アクティビティ（卓球・麻雀）",
     description:
       "天気に左右されず楽しめる卓球台・麻雀台を2階に完備。滞在中に「やることが尽きない」工夫があります。",
-    Icon: TableTennisIcon,
+    image: tableTennisImg,
+    alt: "卓球台の様子",
   },
   {
     title: "レンタル用品（SUP等）",
     description:
       "SUPをはじめとするレンタル用品を用意しています。海でのアクティビティを手ぶらで楽しみたい方に向いています。",
-    Icon: SurfIcon,
-  },
-  {
-    title: "海まで徒歩約30秒・館山駅から徒歩約9分",
-    description:
-      "北条海岸まで徒歩約30秒の好立地です。館山駅からも徒歩約9分でアクセスでき、車なしでも動きやすい環境です。",
-    Icon: MapPinIcon,
+    image: sapImg,
+    alt: "サップ（SUP）のレンタル用品の様子",
   },
 ];
 
 // ────────────────────────────────────────────────────────
-// 特徴カード（1枚のカードを表示するコンポーネント）
+// FeatureCard（写真付きビジュアルカード）
 // ────────────────────────────────────────────────────────
 
 /**
- * FeatureCard — 個別の特徴を1枚のカードとして表示する
+ * FeatureCard — 個別の特徴を写真付きビジュアルカードとして表示する
  *
- * 構成: アイコン（装飾）→ h3 見出し → 説明文
- * デザイン: bg-stone-100 / rounded-xl / shadow-sm（docs/DESIGN.md §8.5、Issue #23 でstone系に統一）
+ * レイアウト:
+ *   - スマホ: 写真上 + テキスト下（flex-col）
+ *   - PC (sm〜): 写真と テキストを横並び（flex-row）
+ *     - reversed=true のとき写真を右に配置（flex-row-reverse）で左右交互を実現
+ *
+ * 写真:
+ *   - モバイル: aspect-[4/3]（アスペクト比を固定してレイアウトズレを防ぐ）
+ *   - PC: 親の高さに合わせて伸縮（self-stretch + position:relative + Image fill）
+ *   - next/image の sizes でレスポンシブ画像配信を最適化
+ *
+ * デザイン: rounded-xl / shadow-sm / bg-stone-100（Issue #23 stone系カラー統一）
  */
-function FeatureCard({ title, description, Icon }: Feature) {
+function FeatureCard({
+  title,
+  description,
+  image,
+  alt,
+  reversed,
+}: Feature & {
+  /**
+   * true のとき写真を右側に配置（左右交互レイアウト用）
+   * PC では flex-row-reverse で順序を反転する
+   */
+  reversed: boolean;
+}) {
   return (
-    <article className="flex flex-col gap-4 rounded-xl bg-stone-100 p-6 shadow-sm dark:bg-zinc-800">
-      {/* アイコン（装飾用。aria-hidden で読み上げをスキップ） */}
-      {/* Issue #26: bg-sky-50 / text-sky-600 でブランドカラーのアクセントを付与 */}
-      {/* dark モードは sky-900/40 背景 + sky-400 アイコンで視認性を維持 */}
-      <div
-        aria-hidden="true"
-        className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-50 text-sky-600 dark:bg-sky-900/40 dark:text-sky-400"
-      >
-        <Icon />
-      </div>
+    <article
+      className={[
+        "flex overflow-hidden rounded-xl bg-stone-100 shadow-sm dark:bg-zinc-800",
+        // スマホ: 縦積み（写真上・テキスト下）
+        "flex-col",
+        // SM以上: 横並び。reversed の場合は写真を右へ
+        reversed ? "sm:flex-row-reverse" : "sm:flex-row",
+      ].join(" ")}
+    >
+      {/* ── 写真エリア ── */}
       {/*
-       * h3: Section（h2）の下に置くことで見出し階層を維持する
-       * docs/DESIGN.md §2.2 「階層を飛ばさない」
+       * モバイル: aspect-[4/3] で縦高さを確保（fill を使うために relative が必要）
+       * PC: sm:w-1/2 で半分の幅、sm:aspect-auto で aspect-[4/3] を解除し
+       *     自分自身の高さはテキスト側に合わせる（self-stretch は親 flex が決める）
        */}
-      <h3 className="text-lg font-semibold leading-snug text-stone-900 dark:text-zinc-50">
-        {title}
-      </h3>
-      {/* 説明文: text-base / leading-7 で読みやすい行間を確保 */}
-      <p className="text-base leading-7 text-stone-600 dark:text-zinc-400">
-        {description}
-      </p>
+      <div className="relative aspect-[4/3] sm:aspect-auto sm:w-1/2">
+        <Image
+          src={image}
+          alt={alt}
+          fill
+          /*
+           * object-cover: 写真のアスペクト比を保ちつつ枠全体を覆う
+           * コンテナに収まらない部分はクリップされる
+           */
+          className="object-cover"
+          /*
+           * sizes: ブラウザが事前に読み込む画像サイズを最適化するヒント
+           * スマホ（100vw）+ PC（50vw = 2カラムの片方）
+           */
+          sizes="(min-width: 640px) 50vw, 100vw"
+        />
+      </div>
+
+      {/* ── テキストエリア ── */}
+      {/*
+       * justify-center: 写真と高さが合わないとき縦方向に中央揃え
+       * sm:w-1/2: PC では写真と同じ幅の半分を占める
+       */}
+      <div className="flex flex-col justify-center gap-4 p-6 sm:w-1/2">
+        {/*
+         * h3: Section（h2）の下に置くことで見出し階層を維持する
+         * docs/DESIGN.md §2.2 「階層を飛ばさない」
+         */}
+        <h3 className="text-lg font-semibold leading-snug text-stone-900 dark:text-zinc-50">
+          {title}
+        </h3>
+        {/* 説明文: text-base / leading-7 で読みやすい行間を確保 */}
+        <p className="text-base leading-7 text-stone-600 dark:text-zinc-400">
+          {description}
+        </p>
+      </div>
     </article>
   );
 }
@@ -254,15 +208,19 @@ export function FeaturesSection() {
       variant="tinted"
     >
       {/*
-       * カードグリッド
-       * - モバイル: 1カラム
-       * - sm（640px〜）: 2カラム
-       * - lg（1024px〜）: 3カラム → 5枚 = 1行3枚 + 1行2枚
-       * list/ul を使わずグリッドのみで並べる（独立した記事として article を使用）
+       * ビジュアルカードリスト
+       * - 各カードが1行を占める縦積み（gap-6 で間隔を確保）
+       * - PC では各カード内部が左右2カラムになる（FeatureCard 内の flex-row）
+       * - 奇数番目のカード（index が奇数）は写真を右側に反転（reversed=true）
+       *   → 交互配置により単調さを避け、視線の流れを作る
        */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
-        {FEATURES.map((feature) => (
-          <FeatureCard key={feature.title} {...feature} />
+      <div className="flex flex-col gap-6">
+        {FEATURES.map((feature, index) => (
+          <FeatureCard
+            key={feature.title}
+            {...feature}
+            reversed={index % 2 !== 0}
+          />
         ))}
       </div>
     </Section>


### PR DESCRIPTION
## 概要

「選ばれる理由」セクションのアイコン+テキストカードを、写真+テキストのビジュアルカードレイアウトに刷新します。

Closes #35

## 変更ファイル

- `app/_components/FeaturesSection.tsx`（1ファイルのみ）

## 変更内容

| 変更項目 | 変更前 | 変更後 |
|---|---|---|
| カードUX | アイコン（SVG）＋テキスト | **写真**＋テキスト |
| PCレイアウト | 3カラムグリッド | 1列縦積み、左右2カラム交互 |
| スマホレイアウト | 1〜2カラムグリッド | 写真上・テキスト下 縦積み |
| Feature型 | `Icon: () => JSX.Element` | `image: StaticImageData` + `alt: string` |
| カード数 | 5枚（立地含む） | 5枚（屋上テラス・ウッドデッキを個別化、立地は除外） |

### 特徴と使用写真の対応

| 特徴 | 写真 |
|---|---|
| 1棟貸し（4〜8名） | `imgs/living.jpg` |
| 屋上テラス | `imgs/rooftop-terrace.jpg` |
| 1階ウッドデッキ | `imgs/wood-terrace.jpg` |
| 室内アクティビティ（卓球・麻雀） | `imgs/table-tennis.jpg` |
| レンタル用品（SUP等） | `imgs/sap.jpg` |

> **立地フィーチャーの除外理由**
> Issue #35 の写真対応表に立地フィーチャー向けの写真が定義されていないため除外。
> 立地情報（海まで徒歩約30秒・館山駅から徒歩約9分）は AccessSection でカバー済み。

## AC 確認

- [x] 各特徴カードに写真が表示される
- [x] テキストと写真のコントラストが保たれている（写真エリアとテキストエリアを物理分離）
- [x] スマホ・PCで崩れない（`aspect-[4/3]` + `sm:flex-row` + `sm:w-1/2`）
- [x] アイコンを写真に置き換えて削除（SVG 5関数すべて削除）

## テスト手順（手動確認）

1. `npm run dev` → http://localhost:3000 を開く
2. 「選ばれる理由」セクションを確認
   - **PC（640px以上）**: 5枚のカードが左右2カラムで交互に並ぶことを確認
   - **スマホ（639px以下）**: 写真が上・テキストが下の縦積みになることを確認
3. 各カードに写真が表示され、テキストが読みやすいことを確認
4. DevTools > Lighthouse で CLS（レイアウトズレ）が発生しないことを確認

## リスク・ロールバック

- **影響範囲**: `FeaturesSection.tsx` 1ファイルのみ
- **ロールバック**: `git revert` で即時戻し可能
- **画像パス**: `imgs/` 以下の静的インポートのため、Vercel / Next.js が自動で WebP 最適化

Closes #35