### PR TITLE
feat(pricing): 料金シミュレーター（日付→シーズン自動判定） #54

### DIFF
--- a/app/_components/PriceSimulator.tsx
+++ b/app/_components/PriceSimulator.tsx
@@ -1,0 +1,215 @@
+/**
+ * PriceSimulator — 料金シミュレーター
+ *
+ * 役割: 宿泊日と宿泊人数を選ぶと、シーズンを自動判定して料金を即時表示する
+ *       インタラクティブなウィジェット。
+ *
+ * 技術:
+ *   - "use client": ユーザー操作（日付選択・人数選択）に useState で反応するため
+ *   - <input type="date">: ネイティブの日付ピッカー（外部ライブラリなし）
+ *   - detectSeason: app/_lib/seasonDetector.ts の判定ロジックを使用
+ *   - PRICING_ROWS / SEASONS: app/_lib/pricingData.ts の共有データを使用
+ *
+ * 注意:
+ *   - トップシーズン（GW・お盆等）は「都度設定」のため、参考料金として表示する
+ *   - 祝日データは 2025〜2027 年分のみ精度が保証される
+ */
+
+"use client";
+
+import { useState } from "react";
+
+import { PRICING_ROWS, SEASONS, yen } from "../_lib/pricingData";
+import { detectSeason } from "../_lib/seasonDetector";
+
+/** シミュレーターが保持する状態 */
+type SimulatorState = {
+  /** 選択した宿泊日（"YYYY-MM-DD" 形式 or 空文字） */
+  dateStr: string;
+  /** 選択した宿泊人数（null = 未選択） */
+  guests: number | null;
+};
+
+export function PriceSimulator() {
+  // ── 状態管理 ──────────────────────────────────────
+  const [state, setState] = useState<SimulatorState>({
+    dateStr: "",
+    guests: null,
+  });
+
+  // ── 計算ロジック ───────────────────────────────────
+
+  /**
+   * 選択状態から結果を導く
+   * dateStr と guests が両方入力されたときだけ計算する
+   */
+  const result = (() => {
+    if (!state.dateStr || state.guests === null) return null;
+
+    // "YYYY-MM-DD" → Date に変換
+    // ※ new Date("YYYY-MM-DD") は UTC 解釈になるため、
+    //    タイムゾーンずれを防ぐために分割してローカル日付として構築する
+    const [y, m, d] = state.dateStr.split("-").map(Number);
+    const date = new Date(y, m - 1, d); // 月は 0 始まり
+
+    const seasonKey = detectSeason(date);
+    const row = PRICING_ROWS.find((r) => r.guests === state.guests);
+    const seasonConfig = SEASONS.find((s) => s.key === seasonKey)!;
+
+    if (!row) return null;
+
+    return {
+      seasonConfig,
+      price: row.prices[seasonKey],
+      isTop: seasonKey === "top",
+    };
+  })();
+
+  // ── イベントハンドラー ─────────────────────────────
+
+  /** 日付が変更されたときに状態を更新する */
+  function handleDateChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setState((prev) => ({ ...prev, dateStr: e.target.value }));
+  }
+
+  /** 人数ボタンが押されたときに状態を更新する */
+  function handleGuestsSelect(guests: number) {
+    setState((prev) => ({ ...prev, guests }));
+  }
+
+  // ── レンダリング ───────────────────────────────────
+
+  return (
+    /*
+     * シミュレーターカード全体
+     * rounded-2xl border: 料金テーブルと視覚的に区別できるよう外枠を強調
+     * bg-stone-50: 通常の白背景より少し落ち着いたトーンで「入力エリア感」を出す
+     */
+    <div className="rounded-2xl border border-stone-200 bg-stone-50 p-5 dark:border-zinc-700 dark:bg-zinc-900/60">
+      {/* カードヘッダー */}
+      <p className="text-sm font-semibold uppercase tracking-wider text-stone-500 dark:text-zinc-400">
+        料金シミュレーター
+      </p>
+      <p className="mt-1 text-xs text-stone-500 dark:text-zinc-400">
+        宿泊日と人数を選ぶと、概算料金をその場で確認できます。
+      </p>
+
+      {/* ── 入力エリア ── */}
+      <div className="mt-4 space-y-4">
+        {/* 日付ピッカー */}
+        <div>
+          <label
+            htmlFor="sim-date"
+            className="block text-sm font-medium text-stone-700 dark:text-zinc-300"
+          >
+            宿泊日
+          </label>
+          {/*
+           * input[type="date"]: ブラウザネイティブのカレンダーを使う
+           * min/max: 祝日データの対応年（2025〜2027年）に絞る
+           */}
+          <input
+            id="sim-date"
+            type="date"
+            min="2025-01-01"
+            max="2027-12-31"
+            value={state.dateStr}
+            onChange={handleDateChange}
+            className="
+              mt-1 block w-full rounded-lg border border-stone-300 bg-white px-3 py-2
+              text-sm text-stone-900
+              focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500
+              dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-50
+              dark:focus:border-sky-400 dark:focus:ring-sky-400
+            "
+          />
+        </div>
+
+        {/* 宿泊人数ボタン */}
+        <div>
+          <p className="text-sm font-medium text-stone-700 dark:text-zinc-300">
+            宿泊人数
+          </p>
+          {/*
+           * 4〜8名を横並びボタンで選択する
+           * 選択中ボタンは bg-sky-700 で強調表示
+           */}
+          <div className="mt-1 flex gap-2">
+            {PRICING_ROWS.map((row) => {
+              const isSelected = state.guests === row.guests;
+              return (
+                <button
+                  key={row.guests}
+                  type="button"
+                  onClick={() => handleGuestsSelect(row.guests)}
+                  aria-pressed={isSelected}
+                  className={`
+                    flex-1 rounded-lg border py-2 text-sm font-medium transition-colors
+                    ${
+                      isSelected
+                        ? "border-sky-600 bg-sky-700 text-white dark:border-sky-500 dark:bg-sky-600"
+                        : "border-stone-200 bg-white text-stone-700 hover:border-sky-300 hover:bg-sky-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-sky-500 dark:hover:bg-sky-950"
+                    }
+                  `}
+                >
+                  {row.guests}名
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* ── 結果エリア ── */}
+      <div className="mt-5 rounded-xl border border-stone-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
+        {result === null ? (
+          /* 未選択状態のプレースホルダー */
+          <p className="text-center text-sm text-stone-400 dark:text-zinc-500">
+            宿泊日と人数を選ぶと料金が表示されます
+          </p>
+        ) : (
+          /* 結果表示 */
+          <div className="space-y-2">
+            {/* シーズンバッジ: 判定されたシーズンを色付きで表示 */}
+            <span
+              className={`inline-block rounded-full border px-3 py-0.5 text-xs font-semibold ${result.seasonConfig.badgeColor}`}
+            >
+              {result.seasonConfig.label}シーズン
+            </span>
+
+            {/* 料金（大きく表示） */}
+            <div className="flex items-baseline gap-2">
+              <span className="text-3xl font-bold tabular-nums text-stone-900 dark:text-zinc-50">
+                {yen(result.price)}
+              </span>
+              <span className="text-sm text-stone-500 dark:text-zinc-400">
+                清掃費込み / 1泊
+              </span>
+            </div>
+
+            {/* 人数・シーズン期間の補足 */}
+            <p className="text-xs text-stone-500 dark:text-zinc-400">
+              {state.guests}名（
+              {PRICING_ROWS.find((r) => r.guests === state.guests)?.note}
+              ）・{result.seasonConfig.description}
+            </p>
+
+            {/* トップシーズンの注意書き */}
+            {result.isTop && (
+              <p className="mt-1 rounded-lg bg-red-50 px-3 py-2 text-xs leading-5 text-red-700 dark:bg-red-950 dark:text-red-300">
+                ※ GW・お盆・シルバーウィーク・年末年始は都度設定になる場合があります。
+                上記は参考料金です。詳細はお問い合わせください。
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 注記 */}
+      <p className="mt-3 text-xs text-stone-400 dark:text-zinc-500">
+        ※ 本シミュレーターは 2025〜2027 年に対応しています。
+        祝日・シーズン判定は参考値です。
+      </p>
+    </div>
+  );
+}

--- a/app/_components/PricingSection.tsx
+++ b/app/_components/PricingSection.tsx
@@ -5,12 +5,14 @@
  *
  * 構成:
  *   1. 料金サマリー（最安値・前提を一目で把握）＋「料金を見る」アンカー導線
- *   2. シーズン定義カード（料金表前に期間を先出し）
- *   3. 詳細料金表（シーズン × 宿泊人数）
- *   4. キャンセルポリシー
- *   5. レンタル料金
+ *   2. 料金シミュレーター（日付＋人数 → シーズン自動判定 → 料金表示）
+ *   3. シーズン定義カード（料金表前に期間を先出し）
+ *   4. 詳細料金表（シーズン × 宿泊人数）
+ *   5. キャンセルポリシー
+ *   6. レンタル料金
  *
  * データの根拠: docs/FACTS.md（確定情報のみ）
+ * 料金データ: app/_lib/pricingData.ts（PriceSimulator と共有）
  */
 
 import Image, { StaticImageData } from "next/image";
@@ -19,100 +21,12 @@ import sapImg from "../../imgs/sap.jpg";
 import wetSuitImg from "../../imgs/wet-suit.jpg";
 import lifeJacketImg from "../../imgs/life-jacket.jpg";
 import { ANCHOR_IDS } from "../_lib/anchors";
+import { PRICING_ROWS, SEASONS, yen } from "../_lib/pricingData";
+import { PriceSimulator } from "./PriceSimulator";
 import { Section } from "./Section";
 
-// ---- 料金データ（docs/FACTS.md の確定値をそのまま使用） ----
-// ※ 計算式（base + extra × count）だと端数が合わないため、絶対値で管理する
-
-/** 1 行分の宿泊人数データ */
-type PriceRow = {
-  /** 宿泊人数 */
-  guests: number;
-  /** 使用フロアの補足 */
-  note: string;
-  /**
-   * シーズン別の料金（円）
-   * offseason: オフシーズン
-   * regular:   レギュラーシーズン
-   * high:      ハイシーズン
-   * top:       トップシーズン
-   */
-  prices: {
-    offseason: number;
-    regular: number;
-    high: number;
-    top: number;
-  };
-};
-
-/** 宿泊料金テーブル（清掃費込み） */
-const PRICING_ROWS: PriceRow[] = [
-  {
-    guests: 4,
-    note: "1階のみ",
-    prices: { offseason: 46000, regular: 53000, high: 58000, top: 63000 },
-  },
-  {
-    guests: 5,
-    note: "1・2階",
-    prices: { offseason: 48500, regular: 56500, high: 61500, top: 66500 },
-  },
-  {
-    guests: 6,
-    note: "1・2階",
-    prices: { offseason: 51000, regular: 60000, high: 65000, top: 70000 },
-  },
-  {
-    guests: 7,
-    note: "1・2階",
-    prices: { offseason: 53500, regular: 63500, high: 68500, top: 73500 },
-  },
-  {
-    guests: 8,
-    note: "1・2階",
-    prices: { offseason: 56000, regular: 67000, high: 72000, top: 77000 },
-  },
-];
-
-/**
- * シーズン定義（列ヘッダー・期間説明・カラー）
- * badgeColor: シーズンカードのバッジ色（Tailwindクラス）
- * labelColor: テーブルヘッダーのテキスト色
- */
-const SEASONS = [
-  {
-    key: "offseason" as const,
-    label: "オフシーズン",
-    description: "左記以外",
-    badgeColor:
-      "bg-stone-100 text-stone-600 border-stone-200 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-700",
-    labelColor: "text-stone-600 dark:text-zinc-400",
-  },
-  {
-    key: "regular" as const,
-    label: "レギュラー",
-    description: "日祝・春休み（土曜・祝前日・3連休2日目・7〜9月除く）",
-    badgeColor:
-      "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950 dark:text-sky-400 dark:border-sky-800",
-    labelColor: "text-sky-700 dark:text-sky-400",
-  },
-  {
-    key: "high" as const,
-    label: "ハイ",
-    description: "土曜・祝前日・3連休2日目・7/10〜9/10（お盆除く）",
-    badgeColor:
-      "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-400 dark:border-amber-800",
-    labelColor: "text-amber-700 dark:text-amber-400",
-  },
-  {
-    key: "top" as const,
-    label: "トップ",
-    description: "GW・お盆・シルバーウィーク・年末年始（12/28〜1/7）は都度設定",
-    badgeColor:
-      "bg-red-50 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-800",
-    labelColor: "text-red-700 dark:text-red-400",
-  },
-];
+// PRICING_ROWS, SEASONS は app/_lib/pricingData.ts で一元管理
+// PriceSimulator（クライアントコンポーネント）が共有するため lib 側に移動済み
 
 /** キャンセルポリシー */
 const CANCELLATION_RULES = [
@@ -124,6 +38,7 @@ const CANCELLATION_RULES = [
 /**
  * レンタル料金（写真付き）
  * image: next/image で読み込む静的画像（StaticImageData）
+ *        ← 画像 import が必要なためこのファイルで管理（pricingData.ts には入れない）
  * alt:   スクリーンリーダー向けの代替テキスト
  */
 type RentalItem = {
@@ -162,10 +77,7 @@ const RENTAL_ITEMS: RentalItem[] = [
   },
 ];
 
-/** 数値を円表示にフォーマットする（例: 46000 → "¥46,000"） */
-function yen(amount: number): string {
-  return `¥${amount.toLocaleString("ja-JP")}`;
-}
+// yen 関数は app/_lib/pricingData.ts からインポート済み
 
 export function PricingSection() {
   return (
@@ -215,7 +127,14 @@ export function PricingSection() {
         </p>
       </div>
 
-      {/* ---- 2. シーズン定義カード ---- */}
+      {/* ---- 2. 料金シミュレーター ---- */}
+      {/*
+       * PriceSimulator は「use client」のクライアントコンポーネント。
+       * ユーザーが日付と人数を選ぶとシーズン判定 → 料金をその場で表示する。
+       */}
+      <PriceSimulator />
+
+      {/* ---- 3. シーズン定義カード ---- */}
       {/*
        * テーブルより先にシーズン期間を見せることで「自分はいつ泊まるのか」を
        * 確認してから料金表を読む自然な流れを作る。
@@ -241,7 +160,7 @@ export function PricingSection() {
         ))}
       </div>
 
-      {/* ---- 3. 詳細料金表 ---- */}
+      {/* ---- 4. 詳細料金表 ---- */}
       {/* overflow-x-auto: スマホでも横スクロールで表全体を確認できる */}
       <div className="overflow-x-auto">
         <table className="w-full min-w-[520px] border-collapse text-sm">
@@ -291,7 +210,7 @@ export function PricingSection() {
         </table>
       </div>
 
-      {/* ---- 4. キャンセルポリシー ---- */}
+      {/* ---- 5. キャンセルポリシー ---- */}
       <div>
         {/* headingLevel=3: Section の h2 "料金" の下に位置する小見出し */}
         <h3 className="text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50">
@@ -328,7 +247,7 @@ export function PricingSection() {
         </div>
       </div>
 
-      {/* ---- 5. レンタル料金 ---- */}
+      {/* ---- 6. レンタル料金 ---- */}
       <div>
         <h3 className="text-xl font-semibold tracking-tight text-stone-900 dark:text-zinc-50">
           レンタル料金

--- a/app/_lib/pricingData.ts
+++ b/app/_lib/pricingData.ts
@@ -1,0 +1,136 @@
+/**
+ * pricingData — 料金データの共有モジュール
+ *
+ * 役割: PricingSection（表示）と PriceSimulator（インタラクティブ計算）の
+ *       両方が参照する料金データを一元管理する。
+ *
+ * データ根拠: docs/FACTS.md（確定情報のみ）
+ *
+ * ※ レンタル料金（RENTAL_ITEMS）は画像ファイルの import を伴うため
+ *    PricingSection.tsx 側で引き続き管理する。
+ */
+
+import type { SeasonKey } from "./seasonDetector";
+
+// ─────────────────────────────────────────────
+// 宿泊料金テーブル
+// ─────────────────────────────────────────────
+
+/** 1行分の宿泊人数データ */
+export type PriceRow = {
+  /** 宿泊人数 */
+  guests: number;
+  /** 使用フロアの補足（例: "1階のみ"） */
+  note: string;
+  /**
+   * シーズン別の料金（円）・清掃費込み
+   * offseason: オフシーズン
+   * regular:   レギュラーシーズン
+   * high:      ハイシーズン
+   * top:       トップシーズン
+   */
+  prices: Record<SeasonKey, number>;
+};
+
+/**
+ * 宿泊料金テーブル（清掃費込み）
+ * ※ 計算式（base + extra × count）だと端数が合わないため絶対値で管理
+ */
+export const PRICING_ROWS: PriceRow[] = [
+  {
+    guests: 4,
+    note: "1階のみ",
+    prices: { offseason: 46000, regular: 53000, high: 58000, top: 63000 },
+  },
+  {
+    guests: 5,
+    note: "1・2階",
+    prices: { offseason: 48500, regular: 56500, high: 61500, top: 66500 },
+  },
+  {
+    guests: 6,
+    note: "1・2階",
+    prices: { offseason: 51000, regular: 60000, high: 65000, top: 70000 },
+  },
+  {
+    guests: 7,
+    note: "1・2階",
+    prices: { offseason: 53500, regular: 63500, high: 68500, top: 73500 },
+  },
+  {
+    guests: 8,
+    note: "1・2階",
+    prices: { offseason: 56000, regular: 67000, high: 72000, top: 77000 },
+  },
+];
+
+// ─────────────────────────────────────────────
+// シーズン定義（ラベル・説明・カラー）
+// ─────────────────────────────────────────────
+
+/** シーズン定義の1エントリ */
+export type SeasonConfig = {
+  key: SeasonKey;
+  /** 表示ラベル（例: "ハイ"） */
+  label: string;
+  /** 期間の説明（シーズンカードに表示） */
+  description: string;
+  /**
+   * シーズンカードのバッジに使う Tailwind クラス
+   * bg/text/border を light と dark 両対応で指定する
+   */
+  badgeColor: string;
+  /**
+   * 料金テーブルヘッダーのテキスト色
+   * バッジと同じシーズンカラーを共有する
+   */
+  labelColor: string;
+};
+
+/**
+ * シーズン定義リスト（オフ → レギュラー → ハイ → トップの昇順）
+ * 順序は料金テーブルの列順として使用する
+ */
+export const SEASONS: SeasonConfig[] = [
+  {
+    key: "offseason",
+    label: "オフシーズン",
+    description: "左記以外",
+    badgeColor:
+      "bg-stone-100 text-stone-600 border-stone-200 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-700",
+    labelColor: "text-stone-600 dark:text-zinc-400",
+  },
+  {
+    key: "regular",
+    label: "レギュラー",
+    description: "日祝・春休み（土曜・祝前日・3連休2日目・7〜9月除く）",
+    badgeColor:
+      "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950 dark:text-sky-400 dark:border-sky-800",
+    labelColor: "text-sky-700 dark:text-sky-400",
+  },
+  {
+    key: "high",
+    label: "ハイ",
+    description: "土曜・祝前日・3連休2日目・7/10〜9/10（お盆除く）",
+    badgeColor:
+      "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-400 dark:border-amber-800",
+    labelColor: "text-amber-700 dark:text-amber-400",
+  },
+  {
+    key: "top",
+    label: "トップ",
+    description: "GW・お盆・シルバーウィーク・年末年始（12/28〜1/7）は都度設定",
+    badgeColor:
+      "bg-red-50 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-800",
+    labelColor: "text-red-700 dark:text-red-400",
+  },
+];
+
+// ─────────────────────────────────────────────
+// ユーティリティ
+// ─────────────────────────────────────────────
+
+/** 数値を円表示にフォーマットする（例: 46000 → "¥46,000"） */
+export function yen(amount: number): string {
+  return `¥${amount.toLocaleString("ja-JP")}`;
+}

--- a/app/_lib/seasonDetector.ts
+++ b/app/_lib/seasonDetector.ts
@@ -1,0 +1,267 @@
+/**
+ * seasonDetector — 宿泊日 → シーズン判定
+ *
+ * 役割: 日付（Date）を受け取り、料金シーズンキーを返す純粋関数を提供する。
+ *       外部APIや外部ライブラリに依存せず、祝日・トップシーズン期間を
+ *       固定配列で管理する。
+ *
+ * 判定優先順位（高い順）:
+ *   1. top      — トップシーズン固定期間リスト内
+ *   2. high     — 土曜 / 夏季（7/10〜9/10、お盆除く）/ 祝前日 / 3連休中日
+ *   3. regular  — 日曜 / 祝日 / 春休み（3/20〜4/7）
+ *   4. offseason — それ以外
+ *
+ * データ根拠: docs/FACTS.md
+ * 注意: 2025〜2027 年の祝日を固定配列で管理。それ以外の年は精度が下がる。
+ */
+
+/** シーズンを識別するキー */
+export type SeasonKey = "offseason" | "regular" | "high" | "top";
+
+// ─────────────────────────────────────────────
+// 内部ユーティリティ
+// ─────────────────────────────────────────────
+
+/**
+ * Date を "YYYY-MM-DD" 形式の文字列に変換する
+ * ※ ローカル時刻で計算する（タイムゾーンのずれを防ぐため）
+ */
+function toDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// ─────────────────────────────────────────────
+// 祝日データ（2025〜2027 年）
+// 根拠: 内閣府「国民の祝日について」
+// 振替休日・国民の休日を含む
+// ─────────────────────────────────────────────
+const HOLIDAYS = new Set<string>([
+  // 2025 年
+  "2025-01-01", // 元日
+  "2025-01-13", // 成人の日
+  "2025-02-11", // 建国記念の日
+  "2025-02-23", // 天皇誕生日
+  "2025-02-24", // 振替休日
+  "2025-03-20", // 春分の日
+  "2025-04-29", // 昭和の日
+  "2025-05-03", // 憲法記念日
+  "2025-05-04", // みどりの日
+  "2025-05-05", // こどもの日
+  "2025-05-06", // 振替休日
+  "2025-07-21", // 海の日
+  "2025-08-11", // 山の日
+  "2025-09-15", // 敬老の日
+  "2025-09-22", // 振替休日
+  "2025-09-23", // 秋分の日
+  "2025-10-13", // スポーツの日
+  "2025-11-03", // 文化の日
+  "2025-11-23", // 勤労感謝の日
+  "2025-11-24", // 振替休日
+
+  // 2026 年
+  "2026-01-01", // 元日
+  "2026-01-12", // 成人の日
+  "2026-02-11", // 建国記念の日
+  "2026-02-23", // 天皇誕生日
+  "2026-03-20", // 春分の日
+  "2026-04-29", // 昭和の日
+  "2026-05-03", // 憲法記念日
+  "2026-05-04", // みどりの日
+  "2026-05-05", // こどもの日
+  "2026-05-06", // 振替休日
+  "2026-07-20", // 海の日
+  "2026-08-11", // 山の日
+  "2026-09-21", // 敬老の日
+  "2026-09-22", // 秋分の日
+  "2026-10-12", // スポーツの日
+  "2026-11-03", // 文化の日
+  "2026-11-23", // 勤労感謝の日
+
+  // 2027 年
+  "2027-01-01", // 元日
+  "2027-01-11", // 成人の日
+  "2027-02-11", // 建国記念の日
+  "2027-02-23", // 天皇誕生日
+  "2027-03-21", // 春分の日
+  "2027-04-29", // 昭和の日
+  "2027-05-03", // 憲法記念日
+  "2027-05-04", // みどりの日
+  "2027-05-05", // こどもの日
+  "2027-07-19", // 海の日
+  "2027-08-11", // 山の日
+  "2027-09-20", // 敬老の日
+  "2027-09-23", // 秋分の日
+  "2027-10-11", // スポーツの日
+  "2027-11-03", // 文化の日
+  "2027-11-23", // 勤労感謝の日
+  "2027-11-24", // 振替休日
+]);
+
+// ─────────────────────────────────────────────
+// トップシーズン期間（固定）
+// 根拠: docs/FACTS.md
+// ─────────────────────────────────────────────
+
+/** 期間を "YYYY-MM-DD" の start / end（両端含む）で表す型 */
+type DateRange = { start: string; end: string };
+
+/**
+ * トップシーズンの固定期間リスト
+ * - GW:        4/29〜5/6（毎年）
+ * - お盆:      8/13〜8/16（毎年）
+ * - 年末年始:  12/28〜翌1/7（毎年）
+ * - シルバーウィーク: 発生する年のみ
+ *   - 2025年: 9/13〜9/23（土〜秋分の日）
+ */
+const TOP_SEASON_RANGES: DateRange[] = [];
+
+// 各年の固定期間を生成する
+for (const year of [2025, 2026, 2027]) {
+  // GW
+  TOP_SEASON_RANGES.push({
+    start: `${year}-04-29`,
+    end: `${year}-05-06`,
+  });
+  // お盆
+  TOP_SEASON_RANGES.push({
+    start: `${year}-08-13`,
+    end: `${year}-08-16`,
+  });
+  // 年末（〜12/31）
+  TOP_SEASON_RANGES.push({
+    start: `${year}-12-28`,
+    end: `${year}-12-31`,
+  });
+  // 年始（1/1〜1/7）
+  TOP_SEASON_RANGES.push({
+    start: `${year}-01-01`,
+    end: `${year}-01-07`,
+  });
+}
+// シルバーウィーク 2025（9/13 土〜9/23 秋分の日）
+TOP_SEASON_RANGES.push({ start: "2025-09-13", end: "2025-09-23" });
+
+// ─────────────────────────────────────────────
+// 判定ヘルパー関数（モジュール内部のみ使用）
+// ─────────────────────────────────────────────
+
+/** 日付がトップシーズン固定期間内かどうかを返す */
+function isTopSeason(date: Date): boolean {
+  const ts = toDateString(date);
+  return TOP_SEASON_RANGES.some(({ start, end }) => ts >= start && ts <= end);
+}
+
+/** 日付が祝日（HOLIDAYS セット内）かどうかを返す */
+function isHoliday(date: Date): boolean {
+  return HOLIDAYS.has(toDateString(date));
+}
+
+/**
+ * 日付が「祝前日（翌日が祝日）」かどうかを返す
+ * 例: 1/12（日曜）の前日 1/12 → 1/13 が成人の日なら祝前日
+ */
+function isHolidayEve(date: Date): boolean {
+  const next = new Date(date);
+  next.setDate(next.getDate() + 1);
+  return isHoliday(next);
+}
+
+/**
+ * 日付が「3連休以上の連続した非稼働日の中日」かどうかを返す
+ * 判定: 前日・翌日がともに非稼働日（土日 or 祝日）であること
+ * ※ 厳密な「3連休の2日目」の完全再現は複雑なため、
+ *    「連続3日以上の中にある」で近似する
+ */
+function isMiddleOfConsecutiveHoliday(date: Date): boolean {
+  const prev = new Date(date);
+  prev.setDate(prev.getDate() - 1);
+  const next = new Date(date);
+  next.setDate(next.getDate() + 1);
+
+  // 非稼働日かどうか（土日 or 祝日）
+  const isNonWork = (d: Date): boolean =>
+    d.getDay() === 0 || d.getDay() === 6 || isHoliday(d);
+
+  return isNonWork(prev) && isNonWork(next);
+}
+
+/**
+ * 日付が夏季ハイシーズン（7/10〜9/10）かどうかを返す
+ * お盆期間（8/13〜8/16）はトップシーズンに昇格するため除外
+ */
+function isHighSeasonSummer(date: Date): boolean {
+  const m = date.getMonth() + 1; // 1〜12
+  const d = date.getDate();
+
+  const inRange =
+    (m === 7 && d >= 10) || // 7/10〜7/31
+    m === 8 || // 8月全体
+    (m === 9 && d <= 10); // 9/1〜9/10
+
+  if (!inRange) return false;
+
+  // お盆（8/13〜8/16）はトップシーズンのため除外
+  const isObon = m === 8 && d >= 13 && d <= 16;
+  return !isObon;
+}
+
+/**
+ * 日付が春休み（3/20〜4/7）かどうかを返す
+ * 定義: 春分の日ごろ〜入学式前を春休みとして扱う
+ */
+function isSpringBreak(date: Date): boolean {
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  return (m === 3 && d >= 20) || (m === 4 && d <= 7);
+}
+
+// ─────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────
+
+/**
+ * 日付（Date）からシーズンキーを判定して返す
+ *
+ * 優先順位（高い順）:
+ *   top > high > regular > offseason
+ *
+ * @param date - 判定したい宿泊日
+ * @returns シーズンキー
+ *
+ * @example
+ * detectSeason(new Date("2025-08-14")); // => "top"（お盆期間）
+ * detectSeason(new Date("2025-08-02")); // => "high"（7/10〜9/10・夏季）
+ * detectSeason(new Date("2025-01-20")); // => "regular"（成人の日翌日、月曜祝日）
+ * detectSeason(new Date("2025-02-04")); // => "offseason"（火曜・平日）
+ */
+export function detectSeason(date: Date): SeasonKey {
+  // 1. トップシーズン（固定期間リスト）
+  if (isTopSeason(date)) return "top";
+
+  const dow = date.getDay(); // 0=日曜, 6=土曜
+
+  // 2. ハイシーズン
+  if (
+    dow === 6 || // 土曜日
+    isHighSeasonSummer(date) || // 夏季（7/10〜9/10、お盆除く）
+    isHolidayEve(date) || // 祝前日
+    isMiddleOfConsecutiveHoliday(date) // 3連休以上の中日
+  ) {
+    return "high";
+  }
+
+  // 3. レギュラーシーズン
+  if (
+    dow === 0 || // 日曜日
+    isHoliday(date) || // 祝日
+    isSpringBreak(date) // 春休み（3/20〜4/7）
+  ) {
+    return "regular";
+  }
+
+  // 4. オフシーズン
+  return "offseason";
+}


### PR DESCRIPTION
## 概要
Issue #54 の対応。料金セクションに「宿泊日と人数を選ぶだけで概算料金がわかる」
インタラクティブなシミュレーターを追加。外部APIなし・外部ライブラリなしで実装。

## 変更ファイル

### 新規
| ファイル | 役割 |
|---|---|
| `app/_lib/seasonDetector.ts` | 日付→シーズンキー判定ロジック（純粋関数） |
| `app/_lib/pricingData.ts` | PRICING_ROWS / SEASONS / yen を共有モジュールに分離 |
| `app/_components/PriceSimulator.tsx` | 日付ピッカー＋人数選択→料金即時表示（`"use client"`） |

### 変更
- `app/_components/PricingSection.tsx`
  - `pricingData.ts` からのimportに切り替え（重複定義を削除）
  - `PriceSimulator` を料金サマリーの直下（2番目）に追加
  - セクション番号を 1〜6 に更新

## シーズン判定ロジック
優先順位（高い順）:

1. top — トップシーズン固定期間（GW / お盆 / シルバーウィーク / 年末年始）
2. high — 土曜 / 7/10〜9/10（お盆除く）/ 祝前日 / 3連休中日
3. regular — 日曜 / 祝日 / 春休み（3/20〜4/7）
4. offseason— それ以外


- 祝日データ: 2025〜2027年分を固定配列で管理（外部ライブラリなし）
- トップ期間: 年ごとに DateRange 配列で管理（毎年更新が必要）

## 動作確認項目
- [ ] 日付を選択するとシーズンバッジが表示される
- [ ] 人数（4〜8名）を選択すると料金が即時更新される
- [ ] トップシーズン日（例: 2025/8/14）を選ぶと都度設定の注意書きが出る
- [ ] 日曜・土曜・祝日でシーズン判定が正しく変わる
- [ ] 未選択時はプレースホルダーが表示される
- [ ] モバイル（375px）でレイアウトが崩れない
- [ ] 既存の料金テーブル・シーズンカードが引き続き表示される

## 制限事項（今回のスコープ外）
- 複数泊の料金計算（チェックアウト日）
- 2027年以降の祝日対応（固定配列を毎年更新が必要）
- STORES予約 API との連携（API 非公開のため）

## 関連
Closes #54