### PR TITLE
feat(access): GoogleマップiframeをAccessSectionに埋め込み #60

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,8 @@
 # 予約（外部サイト）
 NEXT_PUBLIC_BOOKING_URL=
 
-# 地図（埋め込み/外部リンク）
+# 地図（外部リンク: 「Googleマップで開く」ボタンのリンク先）
+# 埋め込み地図は SITE.address から自動生成されるため別途設定不要
 NEXT_PUBLIC_MAP_URL=
 
 # 問い合わせ（外部：公式LINE）

--- a/app/_components/AccessSection.tsx
+++ b/app/_components/AccessSection.tsx
@@ -1,17 +1,19 @@
 /**
  * AccessSection — アクセスセクション
  *
- * 役割: 住所・地図リンク・交通手段を表示し、初めて訪れるユーザーの不安を取り除く。
+ * 役割: 住所・埋め込み地図・交通手段を表示し、初めて訪れるユーザーの不安を取り除く。
  *
  * 構成:
  *   1. 住所（郵便番号+住所）
- *   2. 地図 CTA（Googleマップ）
+ *   2. Google Maps 埋め込み iframe（APIキー不要・住所クエリ方式）
+ *   3. 地図 CTA（Googleマップで開く … 補助的なリンクボタン）
  *      - NEXT_PUBLIC_MAP_URL 未設定時は「準備中」で無効化
- *   3. 最寄り情報（駅・海）
- *   4. 交通手段
+ *   4. 最寄り情報（駅・海）
+ *   5. 交通手段
  *
  * データの根拠: docs/FACTS.md（確定情報のみ）
  * 環境変数: NEXT_PUBLIC_MAP_URL（未設定時は地図 CTA が「準備中」）
+ * 地図埋め込み: SITE.address を encodeURIComponent でクエリ化 → APIキー不要
  */
 
 import { ANCHOR_IDS } from "../_lib/anchors";
@@ -30,17 +32,31 @@ const NEARBY = [
 /** 交通手段（確定済み） */
 const TRANSPORT_OPTIONS = ["車", "電車", "バス", "高速ジェット", "フェリー"];
 
+/**
+ * Google Maps 埋め込み用 URL を住所から生成する関数
+ *
+ * - encodeURIComponent: 日本語・記号をURLで安全に扱える文字列に変換する
+ * - output=embed: iframeで地図を表示するための専用パラメータ（APIキー不要）
+ * - hl=ja: 地図の表示言語を日本語に固定する
+ */
+function buildMapEmbedUrl(address: string): string {
+  return `https://maps.google.com/maps?q=${encodeURIComponent(address)}&output=embed&hl=ja`;
+}
+
+/** iframe 埋め込み URL（SITE.address から自動生成） */
+const MAP_EMBED_URL = buildMapEmbedUrl(SITE.address);
+
 export function AccessSection() {
   return (
     // id="access" を設定して、ヘッダーや他セクションの「アクセス」リンクから到達できるようにする
-    // variant="tinted": 最後に柔らかくまとめるオフホワイト帯（Issue #25）
+    // variant="tinted": 最後に柔らかくまとめるオフホワイト帯
     <Section
       id={ANCHOR_IDS.access}
       title="アクセス"
       lead="館山駅から徒歩圈内。海まで徒歩約30秒の好立地です。"
       variant="tinted"
     >
-      {/* ---- 住所 + 地図 CTA ---- */}
+      {/* ---- 住所 + 埋め込み地図 + 地図 CTA ---- */}
       <div className="space-y-4 rounded-xl border border-stone-200 bg-stone-100 p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
         {/* 住所 */}
         <div>
@@ -53,10 +69,31 @@ export function AccessSection() {
         </div>
 
         {/*
-         * 地図 CTA
+         * Google Maps 埋め込み iframe
+         *
+         * - aspect-video: 横16:縦9 の比率で自動的に高さを決める（レスポンシブ対応）
+         * - w-full: 親要素の横幅に追従させる
+         * - loading="lazy": スクロールして表示されるまで読み込みを遅らせる（パフォーマンス最適化）
+         * - title: スクリーンリーダーが「何のiframeか」を読み上げるために必要（アクセシビリティ）
+         * - referrerPolicy: プライバシー配慮（参照元URLをGoogleに送らない）
+         */}
+        <div className="overflow-hidden rounded-lg">
+          <iframe
+            src={MAP_EMBED_URL}
+            title="TATEYAMA BASE 北条 の地図"
+            className="aspect-video w-full"
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+            allowFullScreen
+          />
+        </div>
+
+        {/*
+         * 地図 CTA（補助的なリンクボタン）
+         * 埋め込みマップで場所は確認できるが、アプリで開いてナビしたい人向けに残す。
          * CTAButton に SITE.mapUrl を渡す。
          * undefined（NEXT_PUBLIC_MAP_URL 未設定）の場合は CTAButton が自動で「準備中」に切り替える。
-         * variant="tertiary": 地図リンクは補助的な行動（テキストリンク風）
+         * variant="tertiary": テキストリンク風の控えめなスタイル
          */}
         <CTAButton
           variant="tertiary"


### PR DESCRIPTION
## 概要

Issue #60 の対応。「アクセス」セクションで Google Maps の外部リンクのみ表示されていた問題を解消し、ページ内にGoogle Maps iframe を埋め込む。

## 変更点

### `app/_components/AccessSection.tsx`

- `buildMapEmbedUrl(address)` 関数を追加
  - `SITE.address` を `encodeURIComponent` でURLエンコードして埋め込み用URLを生成
  - APIキー不要（`maps.google.com/maps?q=...&output=embed&hl=ja` 方式）
- 住所ブロック内に `<iframe>` を追加
  - `aspect-video`（16:9）+ `w-full` でレスポンシブ対応
  - `loading="lazy"` でスクロールまで読み込みを遅延（パフォーマンス最適化）
  - `title` 属性でスクリーンリーダー対応（アクセシビリティ）
  - `referrerPolicy="no-referrer-when-downgrade"` でプライバシー配慮
- 既存の「Googleマップで開く」CTAボタンは補助ボタンとして維持

### `.env.example`

- コメントを更新：埋め込み地図は住所から自動生成されるため `NEXT_PUBLIC_MAP_URL` は外部リンク用のみと明記

## 受け入れ条件（AC）

- [x] アクセスセクションに地図が表示される
- [x] スマホ・PC 共に 16:9 比率で表示される
- [x] 「Googleマップで開く」ボタンは引き続き機能する
- [x] `NEXT_PUBLIC_MAP_URL` 未設定でも地図は住所から表示される

## 手動確認手順

1. `npm run dev` を起動
2. ブラウザで `http://localhost:3000` を開く
3. アクセスセクションまでスクロール
4. 地図の表示、「Googleマップで開く」リンクの動作を確認

## ロールバック手順

```bash
git checkout main