### PR TITLE
fix(hero): h1のtracking-tight / leading-tightを緩めてリゾート感を出す

### DIFF
--- a/app/_components/Hero.tsx
+++ b/app/_components/Hero.tsx
@@ -83,8 +83,11 @@ export function Hero() {
       {/* ----- コンテンツ（画像・オーバーレイより手前に表示） ----- */}
       <div className="relative mx-auto w-full max-w-6xl space-y-6 px-4 py-12 sm:px-6 sm:py-16">
         {/* キャッチコピー: h1 はページに 1 つ（docs/DESIGN.md 2.2 より） */}
-        {/* font-bold + text-6xl でインパクトを最大化。leading-tight で行間を詰める */}
-        <h1 className="max-w-2xl text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
+        {/*
+         * leading-snug（行間 1.375）: leading-tight（1.25）より開放的で、宿泊サイトの「ゆったり感」に合わせる
+         * tracking-normal（字間 0）: tracking-tight の「詰め詰め感」をなくしてリゾート感を演出する
+         */}
+        <h1 className="max-w-2xl text-4xl font-bold leading-snug tracking-normal text-white sm:text-5xl lg:text-6xl">
           {CATCH_COPY}
         </h1>
 


### PR DESCRIPTION
## 概要

`Hero.tsx` の h1 に設定していた `tracking-tight`・`leading-tight` を緩め、宿泊サイトらしい開放的なタイポグラフィに変更する。

Closes #63

## 変更内容

| クラス | 変更前 | 変更後 | 理由 |
|--------|--------|--------|------|
| 行間 | `leading-tight`（1.25） | `leading-snug`（1.375） | キャッチコピーに「ゆったり感」を演出 |
| 字間 | `tracking-tight`（-0.025em） | `tracking-normal`（0） | コーポレート的な詰め詰め感を解消し、リゾート感を演出 |

## 変更ファイル

- `app/_components/Hero.tsx`（1ファイルのみ）

## 受け入れ条件（AC）チェック

- [x] h1 の字間・行間が開放的な印象になっている
- [x] 視認性（コントラスト）は WCAG AA 基準を維持している
  - `text-white` + `from-black/65` オーバーレイは変更なし

## 手動確認手順

1. `npm run dev` でローカル起動
2. トップページのファーストビューを確認
3. キャッチコピー「海もアクティビティも…」の字間・行間が以前より広く見えることを確認
4. スマートフォンサイズ（375px）でも視認性が損なわれていないことを確認