### PR TITLE
feat(header): ヘッダーに予約CTAボタンを固定配置する (#72)

### DIFF
--- a/app/_components/CTAButton.tsx
+++ b/app/_components/CTAButton.tsx
@@ -27,6 +27,12 @@ type CTAButtonProps = {
   /** ボタンの重要度（デフォルト: "primary"） */
   variant?: Variant;
   /**
+   * ボタンサイズ（デフォルト: "md"）。
+   * - "sm": ヘッダーなど高さ制限のある箇所に使用（h-9 px-4）
+   * - "md": 通常のCTA（h-11 px-5）
+   */
+  size?: "sm" | "md";
+  /**
    * リンク先 URL。
    * undefined または空文字の場合、ボタンは「準備中」として無効化される。
    */
@@ -48,7 +54,15 @@ type CTAButtonProps = {
 // shadow-sm: DESIGN.md §8.4 準拠（ボタンに軽い影を付けて立体感を出す）
 // transition-colors: opacity だけでなく背景色・枠線色も滑らかに変化させる
 const BASE =
-  "inline-flex h-11 items-center justify-center rounded-lg px-5 text-sm font-medium shadow-sm transition-colors";
+  "inline-flex items-center justify-center rounded-lg text-sm font-medium shadow-sm transition-colors";
+
+/** サイズ別のクラス（height / padding） */
+const SIZE_CLASSES: Record<"sm" | "md", string> = {
+  /** sm: ヘッダーなど縦幅を抑えたい箇所で使用 */
+  sm: "h-9 px-4",
+  /** md: 標準サイズ（セクション内 CTA 等） */
+  md: "h-11 px-5",
+};
 
 /** 有効時の variant 別スタイル */
 const VARIANT_STYLES: Record<Variant, string> = {
@@ -99,6 +113,7 @@ function disabledClass(variant: Variant): string {
 
 export function CTAButton({
   variant = "primary",
+  size = "md",
   href,
   children,
   description,
@@ -106,7 +121,8 @@ export function CTAButton({
 }: CTAButtonProps) {
   // href が undefined / 空文字の場合は「準備中」として無効化
   const isDisabled = !href;
-  const className = `${BASE} ${isDisabled ? disabledClass(variant) : VARIANT_STYLES[variant]}`;
+  // BASE + サイズクラス + variant スタイルを結合
+  const className = `${BASE} ${SIZE_CLASSES[size]} ${isDisabled ? disabledClass(variant) : VARIANT_STYLES[variant]}`;
 
   return (
     <div className="flex flex-col gap-1">

--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getHeaderNavItems } from "../_lib/navigation";
 import { SITE } from "../_lib/site";
+import { CTAButton } from "./CTAButton";
 
 function HeaderLink({
   href,
@@ -40,14 +41,16 @@ export function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-stone-200 bg-white/90 backdrop-blur dark:border-zinc-800 dark:bg-black/80">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
+        {/* サイト名ロゴ：左端固定 */}
         <Link
           href="/"
-          className="text-sm font-semibold tracking-tight text-stone-900 dark:text-zinc-50"
+          className="shrink-0 text-sm font-semibold tracking-tight text-stone-900 dark:text-zinc-50"
         >
           {SITE.name}
         </Link>
 
-        <nav aria-label="主要ナビゲーション">
+        {/* ナビゲーション：スマホでは非表示、sm 以上で表示 */}
+        <nav aria-label="主要ナビゲーション" className="hidden sm:block">
           <ul className="flex items-center gap-4">
             {items.map((item) => (
               <li key={item.key}>
@@ -60,6 +63,23 @@ export function Header() {
             ))}
           </ul>
         </nav>
+
+        {/*
+         * 予約 CTA ボタン：右端固定
+         * - NEXT_PUBLIC_BOOKING_URL 未設定時は「準備中」として無効化される
+         * - shrink-0 でロゴ・ナビが溢れてもボタンが潰れないようにする
+         * - external=true で別タブ（予約サイト）として開く
+         */}
+        <div className="shrink-0">
+          <CTAButton
+            variant="primary"
+            size="sm"
+            href={SITE.bookingUrl}
+            external
+          >
+            ご予約
+          </CTAButton>
+        </div>
       </div>
     </header>
   );

--- a/app/_lib/site.ts
+++ b/app/_lib/site.ts
@@ -2,6 +2,11 @@ export const SITE = {
   name: "TATEYAMA BASE 北条",
   address: "〒294-0045 千葉県館山市北条2278-3",
   /**
+   * 予約サイト URL。
+   * NEXT_PUBLIC_BOOKING_URL 未設定時は undefined → ヘッダー CTA が非表示 or 準備中になる。
+   */
+  bookingUrl: process.env.NEXT_PUBLIC_BOOKING_URL,
+  /**
    * Google Maps URL。
    * NEXT_PUBLIC_MAP_URL 未設定時は undefined → 地図 CTA が「準備中」になる。
    * 確定値: https://maps.app.goo.gl/n8sJhzN3JK3f2L2QA（.env.local に設定して使用）


### PR DESCRIPTION
## 概要

ヘッダー右端に「ご予約」CTAボタン（primary / sm）を固定配置する。
スクロール中も常に予約導線が見える状態にし、予約率の改善を図る。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/_lib/site.ts` | `bookingUrl`（`NEXT_PUBLIC_BOOKING_URL`）を追加 |
| `app/_components/CTAButton.tsx` | `size` prop（`"sm" \| "md"`）を追加。デフォルト `"md"` で既存呼び出し影響なし |
| `app/_components/Header.tsx` | CTAButton インポート・右端配置、nav に `hidden sm:block` 追加 |

## 受け入れ条件チェック

- [x] ヘッダー右端に「ご予約」ボタンが表示される
- [x] `NEXT_PUBLIC_BOOKING_URL` が未設定のとき「準備中」として無効化される
- [x] スマホでも表示が崩れない（SP では nav を非表示にしロゴ + CTA のみ表示）

## 手動確認手順

1. `NEXT_PUBLIC_BOOKING_URL` **未設定**の状態で `npm run dev` 起動
   - ヘッダー右端に「準備中」ボタンが表示されクリック不可であること
2. `.env.local` に `NEXT_PUBLIC_BOOKING_URL=https://example.com` を設定して再起動
   - ボタン文言が「ご予約」になり、クリックで別タブが開くこと
3. ブラウザ幅を 375px（スマホ相当）に縮小
   - ロゴ + 「ご予約」ボタンのみが表示され、ナビリンクが隠れること
   - ボタンがロゴや縁に重ならないこと

## リスクとロールバック

- `size` prop のデフォルトが `"md"` のため、既存の CTAButton 利用箇所は変更不要
- ロールバック: このコミット 1 件を `git revert` すれば元の状態に戻る
- `NEXT_PUBLIC_BOOKING_URL` 未設定のままでも UI 崩れは発生しない

Closes #72