### PR TITLE
feat(header): モバイル用ハンバーガーメニューを実装する

### DIFF
--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -1,3 +1,7 @@
+// "use client" : useState / useEffect を使うためクライアントコンポーネントにする
+"use client";
+
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { getHeaderNavItems } from "../_lib/navigation";
 import { SITE } from "../_lib/site";
@@ -38,6 +42,19 @@ function DisabledItem({ label }: { label: string }) {
 export function Header() {
   const items = getHeaderNavItems();
 
+  // isOpen: モバイルメニューの開閉状態（true = 開いている）
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Escape キーでメニューを閉じる（キーボード操作アクセシビリティ対応）
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setIsOpen(false);
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    // クリーンアップ: コンポーネント破棄時にリスナーを解除する
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <header className="sticky top-0 z-50 border-b border-stone-200 bg-white/90 backdrop-blur dark:border-zinc-800 dark:bg-black/80">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
@@ -49,7 +66,7 @@ export function Header() {
           {SITE.name}
         </Link>
 
-        {/* ナビゲーション：スマホでは非表示、sm 以上で表示 */}
+        {/* ナビゲーション：sm 以上でのみ表示（スマホでは非表示） */}
         <nav aria-label="主要ナビゲーション" className="hidden sm:block">
           <ul className="flex items-center gap-4">
             {items.map((item) => (
@@ -64,13 +81,13 @@ export function Header() {
           </ul>
         </nav>
 
-        {/*
-         * 予約 CTA ボタン：右端固定
-         * - NEXT_PUBLIC_BOOKING_URL 未設定時は「準備中」として無効化される
-         * - shrink-0 でロゴ・ナビが溢れてもボタンが潰れないようにする
-         * - external=true で別タブ（予約サイト）として開く
-         */}
-        <div className="shrink-0">
+        {/* 右端エリア：予約CTAボタン + ハンバーガーボタン */}
+        <div className="flex shrink-0 items-center gap-2">
+          {/*
+           * 予約 CTA ボタン：常時表示
+           * - NEXT_PUBLIC_BOOKING_URL 未設定時は「準備中」として無効化される
+           * - external=true で別タブ（予約サイト）として開く
+           */}
           <CTAButton
             variant="primary"
             size="sm"
@@ -79,8 +96,103 @@ export function Header() {
           >
             ご予約
           </CTAButton>
+
+          {/*
+           * ハンバーガーボタン：sm 未満（スマホ）でのみ表示
+           * - aria-expanded / aria-controls でスクリーンリーダー対応
+           * - 開いている間は ✕ アイコン、閉じている間は ☰ アイコン
+           */}
+          <button
+            type="button"
+            className="sm:hidden rounded-md p-2 text-stone-700 hover:bg-stone-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            aria-label={isOpen ? "メニューを閉じる" : "メニューを開く"}
+            aria-expanded={isOpen}
+            aria-controls="mobile-menu"
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            {/* 開状態: ✕（閉じるアイコン） */}
+            {isOpen ? (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            ) : (
+              /* 閉状態: ☰（ハンバーガーアイコン） */
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="3" y1="6" x2="21" y2="6" />
+                <line x1="3" y1="12" x2="21" y2="12" />
+                <line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            )}
+          </button>
         </div>
       </div>
+
+      {/*
+       * モバイルメニュー本体
+       * - isOpen が true のときだけレンダリング（sm 以上では sm:hidden で非表示）
+       * - ナビリンク一覧 + 予約CTAボタンを縦並びで表示
+       */}
+      {isOpen && (
+        <div
+          id="mobile-menu"
+          className="sm:hidden border-t border-stone-200 bg-white/95 backdrop-blur dark:border-zinc-800 dark:bg-black/90"
+        >
+          <nav aria-label="モバイルナビゲーション">
+            <ul className="flex flex-col gap-1 px-4 py-3">
+              {items.map((item) => (
+                <li key={item.key}>
+                  {item.disabled || !item.href ? (
+                    <DisabledItem label={item.label} />
+                  ) : (
+                    // リンクをタップしたらメニューを閉じる
+                    <a
+                      href={item.href}
+                      className="block py-2 text-sm font-medium text-stone-900 underline-offset-4 hover:underline dark:text-zinc-50"
+                      onClick={() => setIsOpen(false)}
+                    >
+                      {item.label}
+                    </a>
+                  )}
+                </li>
+              ))}
+              {/* モバイルメニュー内の予約CTAボタン（Issue #73 AC: メニュー内に含める） */}
+              <li className="pt-2">
+                <CTAButton
+                  variant="primary"
+                  size="md"
+                  href={SITE.bookingUrl}
+                  external
+                >
+                  ご予約
+                </CTAButton>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## 概要

スマホ（`sm` 未満）でヘッダーナビをハンバーガーアイコンで折りたたみ、タップで開閉できるようにする。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/_components/Header.tsx` | `"use client"` 化・ハンバーガーボタン追加・モバイルメニュー実装 |

## 変更の要点

- `"use client"` + `useState` でモバイルメニューの開閉状態（`isOpen`）を管理
- `sm:hidden` のボタンにハンバーガー（☰）/クローズ（✕）アイコンを切り替え表示
- タップでメニュー開閉、リンクタップ時も自動クローズ
- `useEffect` で `Escape` キーイベントを監視しメニューを閉じる（キーボード操作対応）
- モバイルメニュー内に予約 CTA ボタンを配置（#72 連携）
- `aria-expanded` / `aria-controls` / `aria-label` でスクリーンリーダー対応
- `useEffect` クリーンアップでメモリリーク防止

## 受け入れ条件（AC）チェック

- [x] `sm` 未満でハンバーガーアイコン（☰）が表示される
- [x] タップでメニューが開閉できる
- [x] メニュー内に予約 CTA ボタンも含める（#72 連携）
- [x] Escape で閉じられる（キーボード操作対応）

## 手動確認手順

1. `npm run dev` 起動 → ブラウザ DevTools でモバイル幅（例: 375px）にリサイズ
2. ヘッダー右端にハンバーガーアイコン（☰）が表示されることを確認
3. アイコンをタップ → メニューが下に展開されることを確認
4. メニュー内に「料金」「アクセス」リンクと「ご予約」ボタンが表示されることを確認
5. メニュー内リンクをタップ → メニューが閉じてスクロールすることを確認
6. メニュー開いた状態で `Escape` キー → メニューが閉じることを確認
7. ブラウザ幅を `sm`（640px）以上にリサイズ → ハンバーガーが消えて横並びナビが表示されることを確認

## 関連 Issue

Closes #73