### PR TITLE
feat(header): ロゴを Shippori Mincho 明朝体テキストロゴにブラッシュアップする

### DIFF
--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -58,10 +58,27 @@ export function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-stone-200 bg-white/90 backdrop-blur dark:border-zinc-800 dark:bg-black/80">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
-        {/* サイト名ロゴ：左端固定 */}
+        {/* ─── サイト名テキストロゴ ───────────────────────────────────────
+             将来 SVG ロゴに差し替える場合はこの <Link> の中身を
+             <SiteLogo /> コンポーネントに置き換えるだけで済むよう
+             ロゴ要素をここ 1 か所に集約している。
+        ─────────────────────────────────────────────────────────── */}
         <Link
           href="/"
-          className="shrink-0 text-sm font-semibold tracking-tight text-stone-900 dark:text-zinc-50"
+          aria-label={`${SITE.name} トップページへ`}
+          className={[
+            "shrink-0",
+            // Shippori Mincho（明朝体）: layout.tsx で --font-shippori-mincho として定義済みの CSS 変数を
+            // Tailwind の任意値構文で参照する。next/font が生成したクラス名に依存しないため型安全。
+            "font-[family-name:var(--font-shippori-mincho)]",
+            // font-semibold (weight:600): 明朝体は細すぎると背景に溶けやすいので midweight で可読性を確保
+            "font-semibold",
+            // tracking-widest: 字間を最大に広げてロゴタイプらしい佇まいにする
+            "tracking-widest",
+            // text-sm / sm:text-base: スマホは小さめ、PC 以上は少し大きくしてロゴ感を強調
+            "text-sm sm:text-base",
+            "text-stone-900 dark:text-zinc-50",
+          ].join(" ")}
         >
           {SITE.name}
         </Link>


### PR DESCRIPTION
## 概要

ヘッダーのサイト名テキストに Shippori Mincho（明朝体）を適用し、
字間・サイズ調整でロゴタイプとして視覚的に仕上げました。

## 変更ファイル

- `app/_components/Header.tsx`

## 変更内容

| 変更点 | Before | After |
|---|---|---|
| フォント | システムサンセリフ | Shippori Mincho（明朝体）|
| 字間 | `tracking-tight` | `tracking-widest` |
| サイズ | `text-sm` 固定 | `text-sm sm:text-base`（レスポンシブ）|
| aria-label | なし | `${SITE.name} トップページへ`（アクセシビリティ向上）|
| 構造コメント | なし | 将来の SVG ロゴ差し替え手順をコメントで明記 |

## 受け入れ条件チェック

- [x] サイト名に Shippori Mincho が適用されている
- [x] `tracking-widest` で字間を広げてロゴらしい見た目になっている
- [x] スマホ（`text-sm`）・PC（`sm:text-base`）どちらでも崩れない
- [x] 将来 SVG ロゴに差し替えやすい構造になっている（コメント＋1 か所集約）

## 手動確認手順

1. `npm run dev` 起動 → `http://localhost:3000` を開く
2. ヘッダー左端の「TATEYAMA BASE 北条」が明朝体・字間広めで表示されること
3. ブラウザ幅をスマホサイズ（375px）に縮めてもロゴが 1 行で収まること
4. ダークモードに切り替えて文字色が白に変わること

## リスクとロールバック手順

- **影響範囲**: `Header.tsx` のロゴ部分のみ（他コンポーネントへの影響なし）
- **ロールバック**: `git revert 51cd837` で即座に元の状態に戻せる

Closes #75