### PR TITLE
feat(global): スクロール連動フェードインアニメーションを実装する (#76)

### DIFF
--- a/app/_components/FadeIn.tsx
+++ b/app/_components/FadeIn.tsx
@@ -1,0 +1,56 @@
+/**
+ * FadeIn — スクロール連動フェードインラッパーコンポーネント（Issue #76）
+ *
+ * 役割:
+ *   子要素を <div> でラップし、表示域に入ったタイミングで
+ *   フェードイン＋スライドアップアニメーションを発火させる。
+ *
+ * 使い方:
+ *   <FadeIn>
+ *     <SomeSection />
+ *   </FadeIn>
+ *
+ * 注意:
+ *   - Hero / SummarySection（ファーストビュー内要素）には **適用しない**
+ *     理由: ページ読み込み直後に見える要素がフラッシュすると UX が悪化するため
+ *   - "use client" が必要な理由: useInView が useEffect / useRef を使うため
+ *
+ * アクセシビリティ:
+ *   globals.css の @media (prefers-reduced-motion: reduce) で
+ *   アニメーションが自動的に無効化されるため、本コンポーネント側での
+ *   追加対応は不要。
+ */
+
+"use client";
+
+import { useInView, type UseInViewOptions } from "../_lib/useInView";
+
+type Props = {
+  children: React.ReactNode;
+  /** 追加で当てたい Tailwind クラスなど */
+  className?: string;
+  /** Intersection Observer のオプション（省略時はデフォルト値を使用） */
+  observerOptions?: UseInViewOptions;
+};
+
+export function FadeIn({ children, className = "", observerOptions }: Props) {
+  // useInView フックから「監視対象の ref」と「表示域に入ったか」を受け取る
+  const { ref, isInView } = useInView(observerOptions);
+
+  return (
+    <div
+      ref={ref}
+      className={[
+        // 表示状態に応じてクラスを切り替える
+        // fade-in-ready  : opacity:0 + translateY(20px)（globals.css で定義）
+        // fade-in-visible: fade-in-up アニメーションを実行（globals.css で定義）
+        isInView ? "fade-in-visible" : "fade-in-ready",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/_lib/useInView.ts
+++ b/app/_lib/useInView.ts
@@ -1,0 +1,72 @@
+/**
+ * useInView — スクロール連動「表示域に入ったか」判定フック（Issue #76）
+ *
+ * 役割:
+ *   Intersection Observer API を使って、要素が表示域（viewport）に
+ *   入ったタイミングを検知し、boolean フラグ `isInView` を返す。
+ *
+ * Intersection Observer とは？
+ *   「ある要素がどのくらい画面に見えているか」をブラウザが非同期に通知する API。
+ *   scroll イベントと異なり、毎フレーム座標計算をしないため CPU 負荷が低い。
+ *
+ * 使い方:
+ *   const { ref, isInView } = useInView();
+ *   <div ref={ref} className={isInView ? "visible" : "hidden"} />
+ *
+ * オプション:
+ *   threshold — 要素の何割が見えたら「表示済み」とするか（0.0〜1.0）
+ *               デフォルト 0.12 = 12% 見えたら発火
+ *   rootMargin — viewport の拡縮マージン（例: "-50px" で少し手前で発火）
+ *
+ * 一度表示されたら Observer を切断するため、再スクロールでリセットされない。
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type UseInViewOptions = Pick<
+  IntersectionObserverInit,
+  "threshold" | "rootMargin"
+>;
+
+export function useInView(options?: UseInViewOptions) {
+  // ref: 監視対象の DOM 要素を参照する
+  const ref = useRef<HTMLDivElement>(null);
+
+  // isInView: 表示域に一度でも入ったら true になる（一方通行）
+  const [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    // SSR（サーバーサイドレンダリング）時は DOM が存在しないためスキップ
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          // 表示域に入ったフラグを立てる
+          setIsInView(true);
+          // 一度表示されたら監視を解除してメモリを解放する
+          observer.disconnect();
+        }
+      },
+      {
+        // threshold: デフォルト 12% 表示で発火（上下に素早くスクロールしても安定）
+        threshold: 0.12,
+        ...options,
+      }
+    );
+
+    observer.observe(el);
+
+    // クリーンアップ: コンポーネントがアンマウントされたら Observer を必ず解除する
+    return () => {
+      observer.disconnect();
+    };
+    // options オブジェクトが毎レンダーで再生成されないよう依存配列は空にする
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { ref, isInView };
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,3 +50,59 @@ body {
   color: var(--foreground);
   /* フォントは layout.tsx で設定した Shippori Mincho を font-sans 経由で適用するため、ここでは指定しない */
 }
+
+/* ============================================================
+ * スクロール連動フェードインアニメーション（Issue #76）
+ * ============================================================
+ *
+ * FadeIn コンポーネントと組み合わせて使う 2 クラス構成:
+ *
+ *   .fade-in-ready   — 初期状態（非表示・少し下にずらす）
+ *   .fade-in-visible — 表示域に入った後（フェードイン実行）
+ *
+ * CSS で実装している理由:
+ *   - framer-motion などの外部ライブラリを追加せずに済む
+ *   - GPU コンポジット対象プロパティ（opacity + transform）のみ使用するため
+ *     レイアウトの再計算（Reflow）が発生せず、パフォーマンスへの影響が最小限
+ * ============================================================ */
+
+/* @keyframes: アニメーションの「開始→終了」の形を定義する
+   translateY(20px) → translateY(0) で「下から上へ」スライドアップ */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* 初期状態: useInView が false の間は非表示かつ 20px 下にオフセット */
+.fade-in-ready {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+/* 表示域に入った後: アニメーション実行して visible に */
+/* forwards: アニメーション終了後も終端状態（opacity:1）を維持する */
+.fade-in-visible {
+  animation: fade-in-up 0.55s ease-out forwards;
+}
+
+/* ============================================================
+ * prefers-reduced-motion: アニメーション無効化（アクセシビリティ対応）
+ * ============================================================
+ * macOS / iOS の「視差効果を減らす」設定や、
+ * Windows の「アニメーションを無効にする」設定がオンの場合に適用される。
+ * 即座に表示状態にしてアニメーションをスキップする。
+ * ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .fade-in-ready,
+  .fade-in-visible {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { AccessSection } from "./_components/AccessSection";
 import { CTAButton } from "./_components/CTAButton";
 import { FacilitiesSection } from "./_components/FacilitiesSection";
+import { FadeIn } from "./_components/FadeIn";
 import { FeaturesSection } from "./_components/FeaturesSection";
 import { Hero } from "./_components/Hero";
 import { PricingSection } from "./_components/PricingSection";
@@ -27,68 +28,79 @@ export default function Home() {
       {/* Features: 特徴（選ばれる理由）
        * 1棟貸し・屋上テラス・室内アクティビティ・レンタル・立地
        * IA.md セクション順 3番め（Summary の後・設備の前）
+       * FadeIn: スクロールで表示域に入ったタイミングでフェードイン（Issue #76）
        */}
-      <FeaturesSection />
+      <FadeIn>
+        <FeaturesSection />
+      </FadeIn>
 
       {/* Facilities: 設備セクション（フロア別一覧）
        * 屋外・1階・2階・屋上・その他の設備を一覧表示
        * IA.md セクション順 4番め（特徴の後・料金の前）
        */}
-      <FacilitiesSection />
+      <FadeIn>
+        <FacilitiesSection />
+      </FadeIn>
 
       {/* Pricing: 宿泊料金・キャンセルポリシー・レンタル料金
        * IA.md セクション順 5番め（設備の後・アクセスの前）
        */}
-      <PricingSection />
+      <FadeIn>
+        <PricingSection />
+      </FadeIn>
 
       {/* Access: 住所・地図 CTA・最寄り・交通手段 */}
-      <AccessSection />
+      <FadeIn>
+        <AccessSection />
+      </FadeIn>
 
       {/* Booking: 予約・問い合わせ CTA（ページ下部で再掲） */}
       {/*
        * variant="accent-dark": bg-sky-700 の濃いブルー帯で予約 CTA を際立たせる（Issue #25）
        * 隣の AccessSection（tinted）とコントラストをつけ、「状態が変わった」ことを視覚的に伝える
        */}
-      <Section
-        id={ANCHOR_IDS.booking}
-        title="予約・問い合わせ"
-        lead="ご予約は外部サービス（STORES）から承ります。ご不明な点はお気軽に LINE でお問い合わせください。"
-        variant="accent-dark"
-      >
-        <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
-          {/*
-           * 予約 CTA（最重要）
-           * variant="outlined-white": accent-dark 帯の上で白枠で際立たせる（Issue #25）
-           * NEXT_PUBLIC_BOOKING_URL 未設定時は「準備中」で自動的に無効化される
-           */}
-          <CTAButton
-            variant="outlined-white"
-            href={bookingUrl}
-            external
-            description={
-              !bookingUrl ? "予約（STORES）は準備中です。" : undefined
-            }
-          >
-            ご宿泊予約
-          </CTAButton>
+      <FadeIn>
+        <Section
+          id={ANCHOR_IDS.booking}
+          title="予約・問い合わせ"
+          lead="ご予約は外部サービス（STORES）から承ります。ご不明な点はお気軽に LINE でお問い合わせください。"
+          variant="accent-dark"
+        >
+          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+            {/*
+             * 予約 CTA（最重要）
+             * variant="outlined-white": accent-dark 帯の上で白枠で際立たせる（Issue #25）
+             * NEXT_PUBLIC_BOOKING_URL 未設定時は「準備中」で自動的に無効化される
+             */}
+            <CTAButton
+              variant="outlined-white"
+              href={bookingUrl}
+              external
+              description={
+                !bookingUrl ? "予約（STORES）は準備中です。" : undefined
+              }
+            >
+              ご宿泊予約
+            </CTAButton>
 
-          {/*
-           * LINE 問い合わせ CTA（補助）
-           * variant="outlined-white": accent-dark 帯の上で白枠、予約ボタンとスタイルを揃える（Issue #25）
-           * NEXT_PUBLIC_LINE_URL 未設定時は「準備中」で自動的に無効化される
-           */}
-          <CTAButton
-            variant="outlined-white"
-            href={SITE.lineUrl}
-            external
-            description={
-              !SITE.lineUrl ? "LINE は準備中です。" : undefined
-            }
-          >
-            LINEで問い合わせ
-          </CTAButton>
-        </div>
-      </Section>
+            {/*
+             * LINE 問い合わせ CTA（補助）
+             * variant="outlined-white": accent-dark 帯の上で白枠、予約ボタンとスタイルを揃える（Issue #25）
+             * NEXT_PUBLIC_LINE_URL 未設定時は「準備中」で自動的に無効化される
+             */}
+            <CTAButton
+              variant="outlined-white"
+              href={SITE.lineUrl}
+              external
+              description={
+                !SITE.lineUrl ? "LINE は準備中です。" : undefined
+              }
+            >
+              LINEで問い合わせ
+            </CTAButton>
+          </div>
+        </Section>
+      </FadeIn>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
各セクションのコンテンツが表示域に入ったタイミングで、フェードイン＋スライドアップするアニメーションを追加しました。

## 変更ファイル一覧
| ファイル | 変更種別 | 内容 |
|---|---|---|
| `app/_lib/useInView.ts` | 新規 | Intersection Observer カスタムフック |
| `app/_components/FadeIn.tsx` | 新規 | フェードインラッパーコンポーネント |
| `app/globals.css` | 変更 | `@keyframes fade-in-up` + `prefers-reduced-motion` 対応 |
| `app/page.tsx` | 変更 | FadeIn を各セクションに適用 |

## 実装の概要

### `useInView.ts`
- Intersection Observer API でスクロール連動を実現（scroll イベント不使用でパフォーマンス良好）
- 一度表示域に入ったら `observer.disconnect()` でメモリ解放
- SSR 安全（`ref.current` の null チェック済み）

### `FadeIn.tsx`
- `"use client"` クライアントコンポーネント
- `isInView` の変化で `fade-in-ready` ↔ `fade-in-visible` クラスを切り替え

### `globals.css`
- `opacity + transform` のみ使用 → Reflow なし、GPU コンポジット対象
- `@media (prefers-reduced-motion: reduce)` でアニメーションを完全無効化

### `page.tsx`
- `FeaturesSection` / `FacilitiesSection` / `PricingSection` / `AccessSection` / Booking セクション に `<FadeIn>` を適用
- **`Hero` / `SummarySection` は除外**（ファーストビュー内のため AC 準拠）

## 受け入れ条件チェック
- [x] 表示域に入った要素がフェードイン（opacity 0→1 + translateY(20px)→0）する
- [x] `prefers-reduced-motion` を尊重しアニメーションを無効化できる
- [x] ファーストビュー内（Hero / SummarySection）には適用しない
- [x] パフォーマンスへの影響が最小限（Intersection Observer + GPU プロパティのみ）

## 手動確認手順
1. `npm run dev` でローカル起動
2. `http://localhost:3000` を開き、Features / Facilities / Pricing / Access / Booking 各セクションへスクロール → フェードインを目視確認
3. Hero / SummarySection はページ読み込み時に即座に表示されることを確認（アニメーションなし）
4. macOS: システム設定 → アクセシビリティ → 「視差効果を減らす」をオン → アニメーションが無効化されることを確認

## リスク・ロールバック
- 影響範囲: `page.tsx` の各セクション表示（機能・導線への影響なし）
- ロールバック: `<FadeIn>` ラッパーを外すだけで即時復元可能

Closes #76