### PR TITLE
feat(summary): SummaryとFeaturesのセクション境界に波形SVG遷移を追加する

### DIFF
--- a/app/_components/SummarySection.tsx
+++ b/app/_components/SummarySection.tsx
@@ -152,9 +152,10 @@ export function SummarySection() {
       aria-labelledby="summary-heading"
       /**
        * bg-sky-600: Hero 直後に海ブルーの accent 帯を置き、施設スペックを目立たせる（Issue #25）
-       * py-10 sm:py-14: 余白を少し広げて帯の存在感を強調
+       * relative overflow-hidden: 下端の波形SVGを絶対配置するためのコンテナ（Issue #78）
+       * pt-10 pb-20 sm:pt-14 sm:pb-24: 下端に波形（高さ ~64px）のぶんだけ余分な padding を確保する
        */
-      className="bg-sky-600 py-10 sm:py-14"
+      className="relative overflow-hidden bg-sky-600 pt-10 pb-20 sm:pt-14 sm:pb-24"
     >
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
         {/*
@@ -208,6 +209,31 @@ export function SummarySection() {
           ))}
         </ul>
       </div>
+
+      {/*
+       * ── 波形ディバイダー（Issue #78） ──────────────────────────
+       * 役割: sky-600 → 白背景（FeaturesSection）への視覚的遷移を滑らかにする
+       * 実装: SVG の絶対配置。viewBox の高さ 64px に合わせた波形パスを使用
+       *   - `preserveAspectRatio="none"`: 横幅にストレッチして隙間ゼロで敷き詰める
+       *   - `fill="white"`: FeaturesSection の背景色（white）に合わせる
+       *   - `aria-hidden="true"`: 装飾用なのでスクリーンリーダーからは隠す
+       * 波形パス: 2周期のサイン波（なだらかで海岸らしいカーブ）
+       *   M0,32 → 左端を中間高さからスタート
+       *   C ... → ベジェ曲線で山・谷を2回くりかえす
+       *   L1440,64 L0,64 Z → 下辺を閉じて塗りつぶし領域を作る
+       */}
+      <svg
+        aria-hidden="true"
+        className="absolute bottom-0 left-0 w-full"
+        viewBox="0 0 1440 64"
+        preserveAspectRatio="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0,32 C240,0 480,64 720,32 C960,0 1200,64 1440,32 L1440,64 L0,64 Z"
+          fill="white"
+        />
+      </svg>
     </section>
   );
 }


### PR DESCRIPTION
## 概要

SummarySection（sky-600帯）→ FeaturesSection（白背景）の切り替えが急だった問題を、下端の波形SVGディバイダーで解消する。

Closes #78

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/_components/SummarySection.tsx` | 波形SVG追加・section に relative/overflow-hidden・下余白調整 |

## 差分方針

波形SVGをSummarySectionの末尾にインラインで追加（外部ファイルなし）:

- `<section>` に `relative overflow-hidden` を追加し、絶対配置のコンテナとして機能させる
- `pb-20 sm:pb-24` で波形（高さ64px）ぶんの下余白を確保する
- `absolute bottom-0 left-0 w-full` + `preserveAspectRatio="none"` で全幅にストレッチ
- 波形パス: 2周期のベジェ曲線（なだらかな海岸カーブ）、`fill="white"` で FeaturesSection 背景に溶け込む
- `aria-hidden="true"` で装飾要素をスクリーンリーダーから除外

## 受け入れ条件確認

- [x] SummarySectionの下端に波形SVGが追加されている
- [x] スマホ・PCどちらでも自然な見た目になっている（`preserveAspectRatio="none"` + `w-full`）

## 手動確認手順

1. `npm run dev` を起動してブラウザで `http://localhost:3000` を開く
2. SummarySectionとFeaturesSectionの境目をスクロールで確認
   - 波形がsky-600帯の下端に表示されていること
   - 波の白い部分がFeaturesSection（白背景）と隙間なく繋がっていること
3. ブラウザの幅をスマホサイズ（375px）に変更して同じく確認

## リスクとロールバック

- **影響範囲**: `SummarySection` 単体。他コンポーネントへの影響なし
- **ロールバック**: `git revert HEAD` でコミット単位で即時巻き戻し可能
- **潜在リスク**: ダークモード使用時に `fill="white"` がFeaturesSectionの `dark:bg-zinc-900` と不一致になるが、現MVPはダークモード未実装のため許容範囲