### PR TITLE
feat(facilities): タブのスクロール可能状態をフェードで表示 (#80)

### DIFF
--- a/app/_components/FacilitiesSection.tsx
+++ b/app/_components/FacilitiesSection.tsx
@@ -367,6 +367,35 @@ export function FacilitiesSection() {
   // onClose を useCallback でメモ化（Lightbox 内 useEffect の安定化）
   const handleLightboxClose = useCallback(() => setLightboxIndex(null), []);
 
+  // ────────────────────────────────────────────────────────
+  // タブスクロールヒント（Issue #80）
+  // スマホでタブが横スクロールできることをフェードで視覚的に伝える
+  // ────────────────────────────────────────────────────────
+
+  // タブリスト要素への参照（scrollLeft / clientWidth / scrollWidth を読み取る）
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  // タブが末端までスクロールされたか。true のときフェードオーバーレイを非表示にする。
+  const [isTabEnd, setIsTabEnd] = useState<boolean>(false);
+
+  // スクロール位置を確認してフェードの表示状態を更新するコールバック
+  // scrollLeft + clientWidth が scrollWidth に限りなく近い = 末端到達とみなす（余白 4px）
+  const updateTabFade = useCallback(() => {
+    const el = tablistRef.current;
+    if (!el) return;
+    setIsTabEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 4);
+  }, []);
+
+  // マウント直後に初期状態を確認し、scroll イベントを登録する
+  // passive: true でスクロール処理を妨げずパフォーマンスを維持
+  useEffect(() => {
+    const el = tablistRef.current;
+    if (!el) return;
+    updateTabFade(); // 初期チェック（PCなどタブが全て収まる場合は最初からフェード不要）
+    el.addEventListener("scroll", updateTabFade, { passive: true });
+    return () => el.removeEventListener("scroll", updateTabFade);
+  }, [updateTabFade]);
+
   // 現在表示中の写真（メイン表示用）
   const activePhoto = activeFacility.photos[activePhotoIndex];
 
@@ -383,39 +412,58 @@ export function FacilitiesSection() {
        * role="tablist": スクリーンリーダーに「タブの集まり」と伝える ARIA ロール
        * ────────────────────────────────────────────────
        */}
-      <div
-        role="tablist"
-        aria-label="フロアを選択"
-        className="flex overflow-x-auto border-b border-stone-200 dark:border-zinc-700"
-      >
-        {FLOOR_FACILITIES.map((facility) => {
-          const isActive = facility.id === activeId;
-          return (
-            <button
-              key={facility.id}
-              role="tab"
-              id={`tab-${facility.id}`}
-              aria-selected={isActive}
-              aria-controls={`panel-${facility.id}`}
-              tabIndex={0}
-              onClick={() => handleTabChange(facility.id)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  handleTabChange(facility.id);
-                }
-              }}
-              className={[
-                "shrink-0 px-5 py-3 text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline-2 focus-visible:outline-sky-500 focus-visible:outline-offset-2",
-                isActive
-                  ? "border-b-2 border-sky-500 text-sky-600 dark:text-sky-400"
-                  : "text-stone-500 hover:text-stone-700 dark:text-zinc-400 dark:hover:text-zinc-200",
-              ].join(" ")}
-            >
-              {facility.floor}
-            </button>
-          );
-        })}
+      {/* スクロールヒント用のラッパー（relative で内部の absolute フェードを保持） */}
+      <div className="relative">
+        <div
+          ref={tablistRef}
+          role="tablist"
+          aria-label="フロアを選択"
+          className="flex overflow-x-auto border-b border-stone-200 dark:border-zinc-700"
+        >
+          {FLOOR_FACILITIES.map((facility) => {
+            const isActive = facility.id === activeId;
+            return (
+              <button
+                key={facility.id}
+                role="tab"
+                id={`tab-${facility.id}`}
+                aria-selected={isActive}
+                aria-controls={`panel-${facility.id}`}
+                tabIndex={0}
+                onClick={() => handleTabChange(facility.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleTabChange(facility.id);
+                  }
+                }}
+                className={[
+                  "shrink-0 px-5 py-3 text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline-2 focus-visible:outline-sky-500 focus-visible:outline-offset-2",
+                  isActive
+                    ? "border-b-2 border-sky-500 text-sky-600 dark:text-sky-400"
+                    : "text-stone-500 hover:text-stone-700 dark:text-zinc-400 dark:hover:text-zinc-200",
+                ].join(" ")}
+              >
+                {facility.floor}
+              </button>
+            );
+          })}
+        </div>
+
+        {/*
+         * スクロールヒントフェード（右端グラデーション）
+         * - pointer-events-none: 下のタブボタンのクリックを妨げない
+         * - md:hidden: PC ではタブが全て表示されるため不要（スマホ専用）
+         * - isTabEnd が true（末端到達）になると opacity-0 で透明化
+         * - 常時 DOM に存在させ opacity トグルで滑らかにフェードアウト
+         */}
+        <div
+          aria-hidden="true"
+          className={[
+            "pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-white to-transparent transition-opacity duration-200 dark:from-zinc-900 md:hidden",
+            isTabEnd ? "opacity-0" : "opacity-100",
+          ].join(" ")}
+        />
       </div>
 
       {/*


### PR DESCRIPTION
## 概要
スマホで `FacilitiesSection` のタブが横スクロールできることをユーザーに伝えるため、タブリスト右端に右向きグラデーションフェードを追加します。

Closes #80

## 変更ファイル
- `app/_components/FacilitiesSection.tsx`

## 変更内容

### 追加した State / Ref / Effect
| 追加物 | 役割 |
|---|---|
| `tablistRef` (`useRef<HTMLDivElement>`) | タブリスト要素を参照し `scrollLeft` / `clientWidth` / `scrollWidth` を取得 |
| `isTabEnd` (`useState<boolean>`) | 末端到達フラグ。`true` のときフェードを `opacity-0` に切り替え |
| `updateTabFade` (`useCallback`) | 末端判定ロジック。`scrollLeft + clientWidth >= scrollWidth - 4px` で末端とみなす |
| `useEffect` | マウント時に初期チェック＋`scroll` イベント登録（`passive: true`） |

### JSX 変更
- `role="tablist"` の `div` を `relative` ラッパーで包む
- `ref={tablistRef}` を tablist に付与
- グラデーションフェード `div` を絶対配置で右端に追加

## 受け入れ条件（AC）チェック
- [x] タブリスト右端に右向きフェード（`linear-gradient`）が表示される
- [x] 最後のタブにスクロール到達したらフェードが消える（`opacity-0` + `transition-opacity duration-200`）
- [x] PCでは表示しない（`md:hidden`）

## レビューポイント
- フェードは DOM に常時存在させ `opacity` トグルで滑らかにアニメーション（mount/unmount だと transition が効かないため）
- `pointer-events-none` + `aria-hidden="true"` でアクセシビリティ・クリック干渉なし
- `passive: true` scroll listener でスクロールパフォーマンスへの影響なし

## 手動確認手順
1. `npm run dev` → ブラウザで施設・設備セクションへ移動
2. DevTools で画面幅 375px（iPhone SE）に設定
3. タブリスト右端にフェードが表示されることを確認
4. タブを横スクロールして「屋上」（末尾タブ）が見えたらフェードが消えることを確認
5. 画面幅を 768px 以上（PC）に戻してフェードが非表示であることを確認