### PR TITLE
feat(pricing): シーズンを月カレンダービジュアルで表示する

### DIFF
--- a/app/_components/PricingSection.tsx
+++ b/app/_components/PricingSection.tsx
@@ -23,6 +23,7 @@ import { ANCHOR_IDS } from "../_lib/anchors";
 import { SEASONS, yen } from "../_lib/pricingData";
 import { PriceSimulator } from "./PriceSimulator";
 import { PricingTableToggle } from "./PricingTableToggle";
+import { SeasonCalendar } from "./SeasonCalendar";
 import { Section } from "./Section";
 
 // PRICING_ROWS, SEASONS は app/_lib/pricingData.ts で一元管理
@@ -119,6 +120,13 @@ export function PricingSection() {
           </div>
         ))}
       </div>
+
+      {/*
+       * 月カレンダービジュアル: 1〜12月をシーズン色で色分け表示する。
+       * SeasonCalendar は "use client" のクライアントコンポーネント。
+       * 現在月の強調表示を行うためのみ分離している。
+       */}
+      <SeasonCalendar />
 
       {/* ---- 3. 詳細料金表 ---- */}
       {/*

--- a/app/_components/SeasonCalendar.tsx
+++ b/app/_components/SeasonCalendar.tsx
@@ -1,0 +1,121 @@
+/**
+ * SeasonCalendar — 月カレンダービジュアル
+ *
+ * 役割: 1〜12月を横並びで表示し、各月をシーズンカラーでハイライトする。
+ *       「自分の宿泊月がどのシーズンか」を色で直感的に伝えるコンポーネント。
+ *
+ * "use client" にしている理由:
+ *   現在月を強調表示するために new Date() を使う必要があり、
+ *   サーバーサイドとクライアントサイドで値がズレないよう
+ *   クライアントコンポーネントとして定義する。
+ *
+ * データ依存:
+ *   SEASONS（app/_lib/pricingData.ts）の months 配列から色を導出する。
+ *   月のハードコードなし。
+ */
+
+"use client";
+
+import { SEASONS } from "../_lib/pricingData";
+
+/** 日本語の月略称（1〜12月） */
+const MONTH_LABELS = [
+  "1月",
+  "2月",
+  "3月",
+  "4月",
+  "5月",
+  "6月",
+  "7月",
+  "8月",
+  "9月",
+  "10月",
+  "11月",
+  "12月",
+] as const;
+
+/**
+ * SEASONS データから「月番号 → シーズン設定」のマップを生成する。
+ * ループで毎回計算する代わりに一度だけ作成してキャッシュする。
+ *
+ * 例: { 1: offseason設定, 5: top設定, ... }
+ */
+const MONTH_SEASON_MAP = new Map(
+  SEASONS.flatMap((season) => season.months.map((m) => [m, season]))
+);
+
+export function SeasonCalendar() {
+  /**
+   * 現在月を取得する（1〜12の数値）。
+   * クライアントコンポーネントなので new Date() はブラウザ上で実行される。
+   */
+  const currentMonth = new Date().getMonth() + 1; // getMonth() は 0 始まりなので +1
+
+  return (
+    <div className="mt-4">
+      {/*
+       * grid-cols-4: モバイルは4列（3行）
+       * sm:grid-cols-6: タブレットは6列（2行）
+       * lg:grid-cols-12: PCは12列（1行）
+       * これにより "折り返して適切に表示される" AC を満たす
+       */}
+      <div className="grid grid-cols-4 gap-1.5 sm:grid-cols-6 lg:grid-cols-12">
+        {MONTH_LABELS.map((label, i) => {
+          const month = i + 1; // 月番号（1〜12）
+          const season = MONTH_SEASON_MAP.get(month); // その月のシーズン設定を取得
+          const isCurrentMonth = month === currentMonth;
+
+          return (
+            <div
+              key={month}
+              className={[
+                "flex flex-col items-center justify-center rounded-lg py-2 text-center text-xs font-medium transition-shadow",
+                /*
+                 * シーズンカラーを適用。
+                 * season が undefined のときはフォールバックとして石色（デフォルト）を使う。
+                 */
+                season
+                  ? season.calendarColor
+                  : "bg-stone-100 text-stone-500 dark:bg-zinc-800 dark:text-zinc-400",
+                /*
+                 * 現在月は ring（輪郭線）でハイライト。
+                 * ring-2 で細いボーダーを付け、ring-offset-1 で背景との間に隙間を作る。
+                 * ring-stone-400: リングの色（シーズン問わず統一）
+                 */
+                isCurrentMonth
+                  ? "ring-2 ring-stone-400 ring-offset-1 dark:ring-zinc-400"
+                  : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              aria-label={`${label}${season ? `（${season.label}シーズン）` : ""}${isCurrentMonth ? "・今月" : ""}`}
+            >
+              <span className="leading-none">{label}</span>
+              {isCurrentMonth && (
+                /* 現在月の下には小さな "今月" ラベルを表示してわかりやすくする */
+                <span className="mt-0.5 text-[10px] opacity-70">今月</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 凡例: どの色がどのシーズンかを説明する */}
+      <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1.5">
+        {SEASONS.map((season) => (
+          <div key={season.key} className="flex items-center gap-1.5">
+            {/* 色見本の正方形 */}
+            <span
+              className={`h-3 w-3 rounded-sm ${season.calendarColor}`}
+              aria-hidden="true"
+            />
+            {/* シーズン名 */}
+            <span className="text-xs text-stone-600 dark:text-zinc-400">
+              {season.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/_lib/pricingData.ts
+++ b/app/_lib/pricingData.ts
@@ -85,6 +85,24 @@ export type SeasonConfig = {
    * バッジと同じシーズンカラーを共有する
    */
   labelColor: string;
+  /**
+   * 月カレンダーカレンダービジュアルに使うセルの Tailwind クラス
+   * bg/text で light と dark 両対応で指定する
+   */
+  calendarColor: string;
+  /**
+   * このシーズンが「代表的」な月の番号配列（1〜12）
+   *
+   * 判定基準（ゲスト視点で最も目立つシーズン）:
+   *   offseason: 1・2・6・10・11・12（閑散期の平日が主体）
+   *   regular:   3・4（春休み・祝日が多い春）
+   *   high:      7・9（海水浴シーズン序盤と後半）
+   *   top:       5・8（GW・お盆のピーク）
+   *
+   * ※ 月単位では季節が重なるため「月の支配的な性格」で割り当てている。
+   *   詳細な日別判定は seasonDetector.ts を参照。
+   */
+  months: number[];
 };
 
 /**
@@ -99,6 +117,8 @@ export const SEASONS: SeasonConfig[] = [
     badgeColor:
       "bg-stone-100 text-stone-600 border-stone-200 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-700",
     labelColor: "text-stone-600 dark:text-zinc-400",
+    calendarColor: "bg-stone-100 text-stone-500 dark:bg-zinc-800 dark:text-zinc-400",
+    months: [1, 2, 6, 10, 11, 12],
   },
   {
     key: "regular",
@@ -107,6 +127,8 @@ export const SEASONS: SeasonConfig[] = [
     badgeColor:
       "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950 dark:text-sky-400 dark:border-sky-800",
     labelColor: "text-sky-700 dark:text-sky-400",
+    calendarColor: "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300",
+    months: [3, 4],
   },
   {
     key: "high",
@@ -115,6 +137,8 @@ export const SEASONS: SeasonConfig[] = [
     badgeColor:
       "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-400 dark:border-amber-800",
     labelColor: "text-amber-700 dark:text-amber-400",
+    calendarColor: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+    months: [7, 9],
   },
   {
     key: "top",
@@ -123,6 +147,8 @@ export const SEASONS: SeasonConfig[] = [
     badgeColor:
       "bg-red-50 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-800",
     labelColor: "text-red-700 dark:text-red-400",
+    calendarColor: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300",
+    months: [5, 8],
   },
 ];
 


### PR DESCRIPTION
## 概要
PricingSection のシーズン定義カードの下に月カレンダービジュアルを追加し、
1〜12月をシーズン色でハイライトする `SeasonCalendar` コンポーネントを新設します。

Closes #82

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `app/_lib/pricingData.ts` | `SeasonConfig` 型に `calendarColor` / `months` フィールドを追加 |
| `app/_components/SeasonCalendar.tsx` | 新規コンポーネント（月カレンダービジュアル + 今月強調 + 凡例） |
| `app/_components/PricingSection.tsx` | `SeasonCalendar` のインポートと配置を追加 |

## AC チェック
- [x] 1〜12月を横並びで表示し、各月をシーズン色でハイライトする
- [x] 現在月を強調表示する（`ring` + "今月" ラベル）
- [x] シーズンデータは `SEASONS.months` から導出しハードコードしない
- [x] スマホでも折り返して適切に表示される（grid-cols-4 → sm:grid-cols-6 → lg:grid-cols-12）

## 実装メモ
- 月カレンダーのシーズン割り当ては「月の支配的な性格」で行っています（詳細な日別判定は `seasonDetector.ts`）
- `SeasonCalendar` を `"use client"` にした理由: 現在月取得（`new Date()`）でクライアント/サーバーのズレを防ぐため

## 手動確認手順
1. `npm run dev` でローカル起動
2. 料金セクションにアクセス → シーズン定義カードの下に月カレンダーが表示される
3. 本日の月（3月）のセルに ring と「今月」ラベルが表示される
4. スマホ幅に縮小 → 4列 × 3行に折り返して表示される
5. ダークモード切替 → 各月のシーズン色が適切に反転する