### PR TITLE
feat(global): 見出しにShippori Mincho（明朝体）を適用しブランド感を強化する #85

### DIFF
--- a/app/_components/Hero.tsx
+++ b/app/_components/Hero.tsx
@@ -109,7 +109,11 @@ export function Hero() {
          * leading-snug（行間 1.375）: leading-tight（1.25）より開放的で、宿泊サイトの「ゆったり感」に合わせる
          * tracking-normal（字間 0）: tracking-tight の「詰め詰め感」をなくしてリゾート感を演出する
          */}
-        <h1 className="max-w-2xl text-4xl font-bold leading-snug tracking-normal text-white sm:text-5xl lg:text-6xlv whitespace-pre-wrap">
+        {/*
+         * font-mincho: Shippori Mincho（明朝体）を適用（Issue #85）
+         * 和の上品さ・リゾート感を演出する。英数字への影響は最小限（latin subsets 込みで読み込み済み）
+         */}
+        <h1 className="font-mincho max-w-2xl text-4xl font-bold leading-snug tracking-normal text-white sm:text-5xl lg:text-6xlv whitespace-pre-wrap">
           {CATCH_COPY}
         </h1>
 

--- a/app/_components/Section.tsx
+++ b/app/_components/Section.tsx
@@ -68,10 +68,12 @@ export function Section({
 }: Props) {
   const HeadingTag = headingLevel === 3 ? "h3" : "h2";
   // headingLevel と variant を組み合わせて見出しのクラスを組み立てる
+  // font-mincho: 見出しに Shippori Mincho（明朝体）を適用して和の上品さを演出する（Issue #85）
+  // headingLevel === 3 のサブ見出しも明朝体で統一する
   const headingClassName =
     headingLevel === 3
-      ? `text-xl font-semibold tracking-tight ${HEADING_COLOR[variant]}`
-      : `text-2xl font-semibold tracking-tight ${HEADING_COLOR[variant]}`;
+      ? `font-mincho text-xl font-semibold tracking-tight ${HEADING_COLOR[variant]}`
+      : `font-mincho text-2xl font-semibold tracking-tight ${HEADING_COLOR[variant]}`;  
 
   return (
     // variant に応じた背景色を適用。py は全 variant 共通

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,8 +34,22 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  /* --font-shippori-mincho は layout.tsx で CSS 変数として注入される */
-  --font-sans: var(--font-shippori-mincho);
+  /*
+   * --font-sans はシステムサンセリフを維持する。
+   * 段落（p）など本文の読みやすさを確保するためゴシック体（sans）を使用。
+   * 見出し（h1/h2）は .font-mincho クラスで明示的に明朝体を適用する（Issue #85）。
+   */
+}
+
+/*
+ * .font-mincho — 明朝体ユーティリティクラス（Issue #85）
+ * ---------------------------------------------------
+ * Shippori Mincho（layout.tsx で注入された CSS 変数）を直接指定する。
+ * h1・h2 など見出しにのみ使用し、和の上品さ・リゾート感を演出する。
+ * 段落（p）は font-sans（ゴシック体）のまま維持し、本文の読みやすさを守る。
+ */
+.font-mincho {
+  font-family: var(--font-shippori-mincho), serif;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## 概要

Shippori Mincho を `layout.tsx` で読み込んでいたが、各コンポーネントへの適用が不十分だった。
本PRで見出し（h1/h2/h3）に明示的に明朝体を適用し、和の上品さ・リゾート感をサイト全体に行き渡らせる。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/globals.css` | `.font-mincho` ユーティリティクラスを追加。`--font-sans` の Mincho 上書きを削除（段落はシステムサンセリフへ） |
| `app/_components/Section.tsx` | h2/h3 の `headingClassName` に `font-mincho` を追加 |
| `app/_components/Hero.tsx` | h1（キャッチコピー）に `font-mincho` を追加 |

## 受け入れ条件（AC）チェック

- [x] `Section.tsx` の `h2` に明朝体クラスを適用する
- [x] `Hero.tsx` のキャッチコピー（h1）にも適用する
- [x] 段落（`p`）は読みやすさのためゴシック体（sans）を維持する（`--font-sans` のMincho上書きを削除）
- [x] 英字部分への影響を確認する（`subsets: ["latin"]` 込みで読み込み済みのため見出し英字はShippori Minchoのlatin glyphで描画される。許容範囲）

## テスト

### 手動確認手順

1. `npm run dev` 起動後、`http://localhost:3000` を開く
2. Hero エリアのキャッチコピー（h1）が明朝体（セリフ体）で表示されているか確認
3. 各セクション見出し（h2）が明朝体で表示されているか確認
4. サブコピー・説明文（p）がゴシック体（システムサンセリフ）を維持しているか確認
5. ダークモード切り替え時も見出しフォントが崩れないか確認

### 自動テスト

型チェック・Lint ともにエラー 0 件（`npx tsc --noEmit` / `npm run lint`）

## リスク・ロールバック

- **リスク**: `.font-sans` マッピング変更により、body フォントがシステムサンセリフに変わる。意図した変更だが視覚的な差分が大きい可能性あり
- **ロールバック**: `git revert HEAD` または当 PR をリバートで即時元に戻せる

Closes #85