### PR TITLE
refactor(page): layout.tsx と page.tsx の metadata をページ分割に備えて整理する (#87)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,9 +17,24 @@ const shipporiMincho = Shippori_Mincho({
 });
 
 export const metadata: Metadata = {
-  title: "TATEYAMA BASE 北条 | 館山・北条海岸の1棟貸し貸別荘",
-  description:
-    "千葉県館山市の貸別荘「TATEYAMA BASE 北条」。海まで徒歩約30秒、館山駅から徒歩約9分。4〜8名で泊まれる1棟貸し。屋上テラス・ウッドデッキ・室内アクティビティ充実。",
+  // metadataBase: OGP画像など相対URLを絶対URLに変換するベースURL
+  // NEXT_PUBLIC_SITE_URL が未設定/空文字の場合は開発用の localhost:3000 にフォールバック
+  // 注意: ?? ではなく || を使う（空文字列も falsy として扱うため）
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+  ),
+  title: {
+    // default: 各ページで title が未定義の場合に使われるタイトル（フォールバック）
+    default: "TATEYAMA BASE 北条",
+    // template: 各ページで title を定義すると「{ページ title} | TATEYAMA BASE 北条」 の形になる
+    template: "%s | TATEYAMA BASE 北条",
+  },
+  // openGraph: SNS シェア時に使われるサイト共通情報（ページ固有値は各 page.tsx で上書き）
+  openGraph: {
+    type: "website",
+    locale: "ja_JP",
+    siteName: "TATEYAMA BASE 北条",
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { AccessSection } from "./_components/AccessSection";
 import { CTAButton } from "./_components/CTAButton";
 import { FacilitiesSection } from "./_components/FacilitiesSection";
@@ -9,6 +10,28 @@ import { Section } from "./_components/Section";
 import { SummarySection } from "./_components/SummarySection";
 import { ANCHOR_IDS } from "./_lib/anchors";
 import { SITE } from "./_lib/site";
+
+// トップページ固有の metadata を定義する。
+// layout.tsx の title.template ("%s | TATEYAMA BASE 北条") を上書きし、
+// absolute を使うことでサイト名が二重にならないようにする。
+export const metadata: Metadata = {
+  title: {
+    // absolute: テンプレートを無視してこのタイトルをそのまま使う
+    absolute: "TATEYAMA BASE 北条 | 館山・北条海岸の1棟貸し貸別荘",
+  },
+  description:
+    "千葉県館山市の貸別荘「TATEYAMA BASE 北条」。海まで徒歩約30秒、館山駅から徒歩約9分。4〜8名で泊まれる1棟貸し。屋上テラス・ウッドデッキ・室内アクティビティ充実。",
+  // openGraph: SNS（X・Facebook等）でシェアされたときに表示される情報
+  // images は OGP 用画像が確定したら追加する（現時点はプレースホルダー）
+  openGraph: {
+    title: "TATEYAMA BASE 北条 | 館山・北条海岸の1棟貸し貸別荘",
+    description:
+      "千葉県館山市の貸別荘「TATEYAMA BASE 北条」。海まで徒歩約30秒、館山駅から徒歩約9分。4〜8名で泊まれる1棟貸し。屋上テラス・ウッドデッキ・室内アクティビティ充実。",
+    url: "/",
+    // OGP画像は公開前に追加予定。追加時は public/ogp.png を配置して下記を有効化:
+    // images: [{ url: "/ogp.png", width: 1200, height: 630, alt: "TATEYAMA BASE 北条" }],
+  },
+};
 
 export default function Home() {
   // 予約 URL が設定されているかを確認する（未設定時は CTAButton が「準備中」を表示）

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -122,6 +122,16 @@
 - 影響：`app/_components/SummarySection.tsx`（`SUMMARY_ITEMS` 配列・グリッド列数・`MapPinIcon`を削除）
 - 代替案：案A（住所を4列目から外し別行で小さく表示）／現状維持で住所をサイズ統一だけ行う
 
+### 2026-03-27
+
+- 決定：`layout.tsx` の metadata を共通デフォルト値（`metadataBase` / `title.template` / 共通 `openGraph`）に絞り、ページ固有の内容は各 `page.tsx` で定義する構造にした（Issue #87）
+- 理由：ページが増えた際に title・description・OGP を個別設定できるようにするため。Next.js App Router の metadata 継承・上書きの仕組みを活用することで、将来のページ分割（`/access`, `/pricing` 等）に対応しやすくなる。
+- 影響：
+  - `app/layout.tsx`：`metadataBase`（`NEXT_PUBLIC_SITE_URL` 環境変数）/ `title.default`（フォールバック）/ `title.template`（`%s | TATEYAMA BASE 北条`）/ `openGraph.siteName` を残す。ページ固有の `description` は削除。
+  - `app/page.tsx`：`title.absolute`（テンプレートを使わず完全タイトルを指定）/ `description` / `openGraph` を定義。OGP 画像は確定後に追加。
+  - 新規ページを追加する場合：各 `page.tsx` に `export const metadata` を定義し、`title`（string か `title.absolute`）/ `description` / `openGraph` を設定する。
+- 代替案：すべての metadata を `layout.tsx` に集約する（ページ固有設定が困難）／`generateMetadata()` 関数を使う（現時点では静的定義で十分）
+
 ### YYYY-MM-DD
 
 - 決定：


### PR DESCRIPTION
## 概要
Next.js App Router の metadata 継承機能を活用し、`layout.tsx` を共通デフォルト値のみに絞り、トップページ固有の title / description / OGP を `page.tsx` で定義する構造に整理しました。
将来 `/access` や `/pricing` などのページを追加したとき、各 `page.tsx` で独立した SEO 設定が可能になります。

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `app/layout.tsx` | `metadataBase` / `title.template` / 共通 `openGraph` のみに絞る。ページ固有の `title`・`description` は削除 |
| `app/page.tsx` | トップページ固有の `title.absolute` / `description` / `openGraph` を追加 |
| `docs/DECISIONS.md` | metadata 設計方針を 2026-03-27 ログに記録 |

## 実装ポイント

### layout.tsx（共通デフォルト）
```ts
export const metadata: Metadata = {
  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"),
  title: {
    default: "TATEYAMA BASE 北条",           // title 未設定ページのフォールバック
    template: "%s | TATEYAMA BASE 北条",     // 各ページが "%s" 部分を差し替える
  },
  openGraph: {
    type: "website",
    locale: "ja_JP",
    siteName: "TATEYAMA BASE 北条",
  },
};
```

### page.tsx（トップページ固有）
```ts
export const metadata: Metadata = {
  title: { absolute: "TATEYAMA BASE 北条 | 館山・北条海岸の1棟貸し貸別荘" },
  description: "千葉県館山市の貸別荘...",
  openGraph: {
    title: "...",
    description: "...",
    url: "/",
    // images は OGP 画像確定後に追加
  },
};
```

## コードレビュー指摘・修正
- `??` ではなく `||` を使用：`NEXT_PUBLIC_SITE_URL` が空文字列のとき `??` はフォールバックしないため `new URL("")` でビルドエラーになる問題を修正

## 受け入れ条件（AC）確認
- [x] `app/page.tsx` にトップページ固有の `export const metadata` が定義されている
- [x] `layout.tsx` の metadata は共通デフォルト値（`metadataBase`, `title.template` 等）に絞られている
- [x] OGP（`openGraph`）フィールドが追加されている（画像は後でよい）
- [x] `docs/DECISIONS.md` に metadata 設計方針が記録されている

## 手動確認手順
1. `npm run dev` を起動
2. ブラウザの DevTools → Elements → `<head>` を確認
   - `<title>TATEYAMA BASE 北条 | 館山・北条海岸の1棟貸し貸別荘</title>`
   - `<meta name="description" content="千葉県館山市の貸別荘...">`
   - `<meta property="og:title" ...>` / `<meta property="og:site_name" content="TATEYAMA BASE 北条">` があること

## 今後の作業（このPRに含まず）
- [ ] `NEXT_PUBLIC_SITE_URL` に本番URLを設定（公開前）
- [ ] `public/ogp.png` を配置して `openGraph.images` を有効化


Closes #87 